### PR TITLE
feat: PrivateERC20 improvements based on ERC-7984

### DIFF
--- a/contracts/token/PrivateERC20/IERC1363Receiver.sol
+++ b/contracts/token/PrivateERC20/IERC1363Receiver.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+interface IERC1363Receiver {
+    function onTransferReceived(address operator, address from, uint256 value, bytes calldata data) external returns (bytes4);
+}

--- a/contracts/token/PrivateERC20/IPrivateERC20.sol
+++ b/contracts/token/PrivateERC20/IPrivateERC20.sol
@@ -83,6 +83,17 @@ interface IPrivateERC20 {
      * This value changes when {approve} or {transferFrom} are called.
      */
     function allowance(address account, bool isSpender) external returns (gtUint64);
+    
+    /**
+     * @dev Re-encrypts the allowance value for the caller so they can decrypt and read it.
+     *
+     * @param account The counterparty address (spender if caller is owner, or owner if caller is spender).
+     * @param isSpender If true, `account` is the spender and caller is the owner.
+     *                  If false, `account` is the owner and caller is the spender.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     */
+    function reencryptAllowance(address account, bool isSpender) external returns (bool);
 
     /**
      * @dev Sets a `value` amount of tokens as the allowance of `spender` over the
@@ -140,3 +151,4 @@ interface IPrivateERC20 {
      */
     function transferFrom(address from, address to, gtUint64 value) external returns (gtBool);
 }
+

--- a/contracts/token/PrivateERC20/PayableToken.sol
+++ b/contracts/token/PrivateERC20/PayableToken.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import {PrivateERC20} from "./PrivateERC20.sol";
+import "../../utils/mpc/MpcCore.sol";
+import "./IERC1363Receiver.sol";
+
+/**
+ * @title PayableToken
+ * @dev Extension of PrivateERC20 that adds ERC-1363-like transferAndCall functionality.
+ */
+contract PayableToken is PrivateERC20 {
+    
+    constructor(string memory name_, string memory symbol_) PrivateERC20(name_, symbol_) {}
+
+    // =============================================================
+    // ERC-1363 Callbacks Implementation
+    // =============================================================
+
+    function _transferAndCall(address from, address to, gtUint64 value, bytes calldata data) internal returns (gtBool) {
+        // 1. Perform standard encrypted transfer
+        gtBool success = _transfer(from, to, value);
+
+        // 2. Optimistic callback: Call the recipient if it is a contract
+        if (to.code.length > 0) {
+            try IERC1363Receiver(to).onTransferReceived(_msgSender(), from, 0, data) returns (bytes4 retval) {
+                require(retval == IERC1363Receiver.onTransferReceived.selector, "TransferAndCall: Invalid callback return");
+            } catch (bytes memory reason) {
+                if (reason.length == 0) {
+                    revert("TransferAndCall: Transfer to non-ERC1363Receiver implementer");
+                } else {
+                    assembly {
+                        revert(add(32, reason), mload(reason))
+                    }
+                }
+            }
+        }
+
+        return success;
+    }
+
+    function transferAndCall(address to, itUint64 calldata value, bytes calldata data) public virtual returns (gtBool) {
+        gtUint64 gtValue = MpcCore.validateCiphertext(value);
+        return _transferAndCall(_msgSender(), to, gtValue, data);
+    }
+    
+    function transferAndCall(address to, uint64 value, bytes calldata data) public virtual returns (gtBool) {
+        gtUint64 gtValue = MpcCore.setPublic64(value);
+        return _transferAndCall(_msgSender(), to, gtValue, data);
+    }
+}


### PR DESCRIPTION
### **PrivateERC20 improvements implemented based on ERC-7984**

####  <span style="color:green">1. PrivateERC20 implements Introspection (ERC165) as ERC-7984 does</span>

The Ethereum ecosystem suffers from a "Discovery Gap" because the original ERC-20 standard predated ERC-165. This forces wallets to rely on centralized Token Lists or fallible heuristics to find assets. **PrivateERC20** has a unique opportunity to correct this by mandating ERC-165.

*   **ERC-1155 & ERC-721:** Mandate ERC-165 for discovery.
*   **ERC-1363:** Strictly requires implementing ERC-165.

##### 1.1 Wallet Discovery & User Experience
*   **The Private Token Problem:** Heuristics might fail for private tokens.
*   **The ERC-165 Solution:** Allows "Privacy-Aware Wallets" to deterministically auto-discover private assets.

##### Implementation
Inheriting from OpenZeppelin's `ERC165` allows `PrivateERC20` to speak the common language of modern infrastructure with minimal overhead.

Implemented in [`PrivateERC20.sol:L72-74`](contracts/token/PrivateERC20/PrivateERC20.sol#L72-L74):

```solidity
    /**
     * @dev See {IERC165-supportsInterface}.
     */
    function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
        return interfaceId == type(IPrivateERC20).interfaceId || super.supportsInterface(interfaceId);
    }
```

#### <span style="color:green"> 2. PrivateERC20 implements Encrypted Total Supply</span>

#### ERC7984 (Confidential Visibility)
*   **Mechanism:** `confidentialTotalSupply()` returns `euint64`.
*   **Utility:** Allows confidentially auditing total supply.

#### PrivateERC20 (Opacity)
*   **Mechanism:** `totalSupply()` returns `0`.

**Implementation:**
`PrivateERC20.sol` now defines `_totalSupply` as `internal` ([L30](contracts/token/PrivateERC20/PrivateERC20.sol#L30)) and implements `confidentialTotalSupply()` at [`PrivateERC20.sol:L83-85`](contracts/token/PrivateERC20/PrivateERC20.sol#L83-L85).

```solidity
    function confidentialTotalSupply() public view virtual returns (ctUint64) {
        return _totalSupply;
    }
```

#### <span style="color:green">3. PayableToken Implements Callbacks (ERC-1363)</span>

#### The "Single-Transaction DeFi" Opportunity
Implementing **ERC-1363** (`transferAndCall`) allows users to deposit/audit in **one transaction**.

*   **DeFi Composability:** Crucial for AMMs and Lending Pools.
*   **Safety:** Uses `IERC1363Receiver` to ensure recipient capability.

**Implementation:**
See [`PayableToken.sol`](contracts/token/PayableToken/PayableToken.sol) for `_transferAndCall` logic.

```solidity
    function _transferAndCall(address from, address to, gtUint64 value, bytes calldata data) internal returns (gtBool) {
        // ... (standard transfer) ...
        // 2. Optimistic callback: Call the recipient if it is a contract
        if (to.code.length > 0) {
            try IERC1363Receiver(to).onTransferReceived(_msgSender(), from, 0, data) returns (bytes4 retval) {
                require(retval == IERC1363Receiver.onTransferReceived.selector, "TransferAndCall: Invalid callback return");
            } catch (bytes memory reason) {
                 // ... (error handling) ...
            }
        }
        return success;
    }
```
