### PR TITLE
feat: add UI-compatible privacy bridge and private ERC20 contracts

### DIFF
--- a/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
+++ b/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.19;
 import "./PrivacyBridge.sol";
 import "../token/PrivateERC20/tokens/PrivateCOTI.sol";
 import "../token/PrivateERC20/IPrivateERC20.sol";
+import "../token/PrivateERC20/ITokenReceiver.sol";
 import "../utils/mpc/MpcCore.sol";
 
 /**

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -38,7 +38,7 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
 
         token = IERC20(_token);
         privateToken = IPrivateERC20(_privateToken);
-    }    
+    }
 
     /**
      * @notice Deposit public ERC20 tokens to receive equivalent private tokens
@@ -75,7 +75,9 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
      * @param amount Amount of private tokens to burn
      * @dev This function requires prior approval on the private token and a native COTI fee.
      */
-    function withdraw(uint256 amount) external payable nonReentrant whenNotPaused {
+    function withdraw(
+        uint256 amount
+    ) external payable nonReentrant whenNotPaused {
         if (amount == 0) revert AmountZero();
         if (msg.value != nativeCotiFee) revert InsufficientCotiFee();
         _checkWithdrawLimits(amount);
@@ -89,15 +91,12 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
         accumulatedFees += feeAmount;
 
         uint256 bridgeBalance = token.balanceOf(address(this));
-        if (bridgeBalance < amountAfterFee) revert InsufficientBridgeLiquidity();
+        if (bridgeBalance < amountAfterFee)
+            revert InsufficientBridgeLiquidity();
 
         // Transfer private tokens from user to bridge (requires prior approval)
         gtUint256 gtAmount = MpcCore.setPublic256(amount);
-        privateToken.transferFrom(
-            msg.sender,
-            address(this),
-            gtAmount
-        );
+        privateToken.transferFrom(msg.sender, address(this), gtAmount);
 
         // Burn private tokens from bridge's balance
         privateToken.burn(amount);

--- a/contracts/token/PrivateERC20/PrivateERC20.sol
+++ b/contracts/token/PrivateERC20/PrivateERC20.sol
@@ -118,7 +118,10 @@ abstract contract PrivateERC20 is
         return 0;
     }
 
-    function mint(address to, uint256 amount) public virtual onlyRole(MINTER_ROLE) {
+    function mint(
+        address to,
+        uint256 amount
+    ) public virtual onlyRole(MINTER_ROLE) {
         gtUint256 gtAmount = MpcCore.setPublic256(amount);
         _mint(to, gtAmount);
     }
@@ -450,12 +453,31 @@ abstract contract PrivateERC20 is
             _updateBalance(to, newToBalance);
         }
 
-        emit Transfer(
-            from,
-            to,
-            MpcCore.offBoardToUser(valueTransferred, from),
-            MpcCore.offBoardToUser(valueTransferred, to)
-        );
+        // When minting or transferring to/from a smart contract (which has no AES key),
+        // we must bypass offBoardToUser to prevent on-chain reverts.
+        ctUint256 memory senderCt;
+        address fromEnc = _getAccountEncryptionAddress(from);
+        if (fromEnc != address(0)) {
+            senderCt = MpcCore.offBoardToUser(valueTransferred, fromEnc);
+        } else {
+            senderCt = ctUint256({
+                ciphertextHigh: ctUint128.wrap(0),
+                ciphertextLow: ctUint128.wrap(0)
+            });
+        }
+
+        ctUint256 memory receiverCt;
+        address toEnc = _getAccountEncryptionAddress(to);
+        if (toEnc != address(0)) {
+            receiverCt = MpcCore.offBoardToUser(valueTransferred, toEnc);
+        } else {
+            receiverCt = ctUint256({
+                ciphertextHigh: ctUint128.wrap(0),
+                ciphertextLow: ctUint128.wrap(0)
+            });
+        }
+
+        emit Transfer(from, to, senderCt, receiverCt);
 
         return result;
     }
@@ -469,9 +491,16 @@ abstract contract PrivateERC20 is
     function _getAccountEncryptionAddress(
         address account
     ) internal view returns (address) {
+        if (account == address(0)) return address(0);
+
         address encryptionAddress = _accountEncryptionAddress[account];
 
         if (encryptionAddress == address(0)) {
+            if (account.code.length > 0) {
+                // Smart contracts don't have AES keys, so we return address(0)
+                // as a signal to bypass encryption in offBoardToUser.
+                return address(0);
+            }
             encryptionAddress = account;
         }
 
@@ -551,17 +580,30 @@ abstract contract PrivateERC20 is
 
         address encryptionAddress = _getAccountEncryptionAddress(owner);
 
-        ctUint256 memory ownerCiphertext = MpcCore.offBoardToUser(
-            value,
-            encryptionAddress
-        );
+        ctUint256 memory ownerCiphertext;
+        if (encryptionAddress != address(0)) {
+            ownerCiphertext = MpcCore.offBoardToUser(value, encryptionAddress);
+        } else {
+            ownerCiphertext = ctUint256({
+                ciphertextHigh: ctUint128.wrap(0),
+                ciphertextLow: ctUint128.wrap(0)
+            });
+        }
 
         encryptionAddress = _getAccountEncryptionAddress(spender);
 
-        ctUint256 memory spenderCiphertext = MpcCore.offBoardToUser(
-            value,
-            encryptionAddress
-        );
+        ctUint256 memory spenderCiphertext;
+        if (encryptionAddress != address(0)) {
+            spenderCiphertext = MpcCore.offBoardToUser(
+                value,
+                encryptionAddress
+            );
+        } else {
+            spenderCiphertext = ctUint256({
+                ciphertextHigh: ctUint128.wrap(0),
+                ciphertextLow: ctUint128.wrap(0)
+            });
+        }
 
         _allowances[owner][spender] = Allowance(
             ciphertext,
@@ -608,9 +650,7 @@ abstract contract PrivateERC20 is
         _approve(owner, spender, newAllowance);
     }
 
-    function _safeOnboard(
-        ctUint256 memory value
-    ) internal returns (gtUint256) {
+    function _safeOnboard(ctUint256 memory value) internal returns (gtUint256) {
         // If both 128-bit ciphertext halves are zero, treat as public zero
         if (
             ctUint128.unwrap(value.ciphertextHigh) == 0 &&


### PR DESCRIPTION
## Changes

Adds 3 contracts from the portal-bridge UI integration work:

- `privacyBridge/PrivacyBridgeCotiNative.sol`
- `privacyBridge/PrivacyBridgeERC20.sol`
- `/privateERC20/PrivateERC20.sol`

## Notes

This PR contains a single, self-contained commit with only these 3 files.