### PR TITLE
Fix: Parity check logic in PrivacyBridge

### DIFF
--- a/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
+++ b/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
@@ -180,13 +180,14 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
             );
             require(MpcCore.decrypt(amountMatch), "Encrypted amount mismatch");
 
-            // Transfer and burn (encrypted input)
-            IPrivateERC20(address(privateCoti)).transferFrom(
+            // Use already-validated gt handle so PrivateCOTI does not re-call
+            // validateCiphertext with a different contract context (signature mismatch)
+            IPrivateERC20(address(privateCoti)).transferFromGT(
                 msg.sender,
                 address(this),
-                encryptedAmount
+                gtAmount
             );
-            gtBool burnOk = privateCoti.burn(encryptedAmount);
+            gtBool burnOk = privateCoti.burnGt(gtAmount);
             require(MpcCore.decrypt(burnOk), "Burn failed");
         } else {
             // Standard withdrawal (public amount)

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -182,9 +182,15 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
             );
             require(MpcCore.decrypt(amountMatch), "Encrypted amount mismatch");
 
-            // Transfer and burn (encrypted input)
-            privateToken.transferFrom(msg.sender, address(this), encryptedAmount);
-            gtBool burnOk = privateToken.burn(encryptedAmount);
+            // Use already-validated gt handle so PrivateERC20 does not re-call
+            // validateCiphertext with a different contract context (signature mismatch)
+            gtBool transferOk = privateToken.transferFromGT(
+                msg.sender,
+                address(this),
+                gtAmount
+            );
+            require(MpcCore.decrypt(transferOk), "Transfer failed");
+            gtBool burnOk = privateToken.burnGt(gtAmount);
             require(MpcCore.decrypt(burnOk), "Burn failed");
         } else {
             // Standard withdrawal (public amount)
@@ -239,7 +245,8 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
     ) external onlyOwner {
         if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
-        if (_token == address(token) || _token == address(privateToken)) revert CannotRescueBridgeToken();
+        if (_token == address(token) || _token == address(privateToken))
+            revert CannotRescueBridgeToken();
 
         IERC20(_token).safeTransfer(to, amount);
     }


### PR DESCRIPTION
Updated the withdrawal flow to use transferFromGT and burnGt. This resolves a signature mismatch error caused by redundant validateCiphertext calls. By passing the already-validated gtUint256 handle from the bridge to the token contract, we avoid a second validation trigger in the nested call that previously caused the MPC protocol to revert.