### PR TITLE
feat: Add Operator role for fee config and admin functions

### DIFF
--- a/contracts/privacyBridge/PrivacyBridge.sol
+++ b/contracts/privacyBridge/PrivacyBridge.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.19;
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 
 /**
@@ -14,7 +15,12 @@ import "@openzeppelin/contracts/utils/math/Math.sol";
  *      (3) Owner operations (limits, fees, pause, withdraw fees, rescue) are centralized; consider timelock/multisig for sensitive actions.
  *      (4) Any new derived bridge must override withdrawFees to perform the actual transfer; base implementation reverts.
  */
-abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable {
+abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessControl {
+    bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
+
+    event OperatorAdded(address indexed account, address indexed by);
+    event OperatorRemoved(address indexed account, address indexed by);
+
     /// @notice Maximum amount that can be deposited in a single transaction
     uint256 public maxDepositAmount;
 
@@ -99,6 +105,40 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable {
         maxWithdrawAmount = type(uint256).max;
         minDepositAmount = 1;
         minWithdrawAmount = 1;
+
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(OPERATOR_ROLE, msg.sender);
+    }
+
+    modifier onlyOperator() {
+        _checkRole(OPERATOR_ROLE, msg.sender);
+        _;
+    }
+
+    function addOperator(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (account == address(0)) revert InvalidAddress();
+        _grantRole(OPERATOR_ROLE, account);
+        emit OperatorAdded(account, msg.sender);
+    }
+
+    function removeOperator(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (account == address(0)) revert InvalidAddress();
+        _revokeRole(OPERATOR_ROLE, account);
+        emit OperatorRemoved(account, msg.sender);
+    }
+
+    function isOperator(address account) external view returns (bool) {
+        return hasRole(OPERATOR_ROLE, account);
+    }
+
+    /**
+     * @dev Overrides Ownable's transferOwnership to automatically grant roles to new owner
+     */
+    function transferOwnership(address newOwner) public override onlyOwner {
+        if (newOwner == address(0)) revert InvalidAddress();
+        super.transferOwnership(newOwner);
+        _grantRole(DEFAULT_ADMIN_ROLE, newOwner);
+        _grantRole(OPERATOR_ROLE, newOwner);
     }
 
     /**
@@ -170,9 +210,9 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable {
     /**
      * @notice Set the deposit fee
      * @param _feeBasisPoints New deposit fee in basis points (max 100,000 = 10%)
-     * @dev Only the owner can call this function
+     * @dev Only the operator can call this function
      */
-    function setDepositFee(uint256 _feeBasisPoints) external onlyOwner {
+    function setDepositFee(uint256 _feeBasisPoints) external onlyOperator {
         if (_feeBasisPoints > MAX_FEE_UNITS) revert InvalidFee();
         depositFeeBasisPoints = _feeBasisPoints;
         emit FeeUpdated("deposit", _feeBasisPoints);
@@ -181,9 +221,9 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable {
     /**
      * @notice Set the withdrawal fee
      * @param _feeBasisPoints New withdrawal fee in basis points (max 10% = 100,000)
-     * @dev Only the owner can call this function
+     * @dev Only the operator can call this function
      */
-    function setWithdrawFee(uint256 _feeBasisPoints) external onlyOwner {
+    function setWithdrawFee(uint256 _feeBasisPoints) external onlyOperator {
         if (_feeBasisPoints > MAX_FEE_UNITS) revert InvalidFee();
         withdrawFeeBasisPoints = _feeBasisPoints;
         emit FeeUpdated("withdraw", _feeBasisPoints);
@@ -192,17 +232,18 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable {
     /**
      * @notice Toggle deposit functionality
      * @param _enabled True to enable, false to disable
+     * @dev Only the operator can call this function
      */
-    function setIsDepositEnabled(bool _enabled) external onlyOwner {
+    function setIsDepositEnabled(bool _enabled) external onlyOperator {
         isDepositEnabled = _enabled;
     }
 
     /**
      * @notice Set the native COTI fee
      * @param _fee Amount in native tokens (wei-equivalent)
-     * @dev Used by ERC20 bridges: they require msg.value >= this value and refund excess to the caller (best-effort).
+     * @dev Used by ERC20 bridges: they require msg.value >= this value and refund excess to the caller (best-effort). Only the operator can call this function.
      */
-    function setNativeCotiFee(uint256 _fee) external onlyOwner {
+    function setNativeCotiFee(uint256 _fee) external onlyOperator {
         nativeCotiFee = _fee;
     }
 
@@ -224,13 +265,13 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable {
      * @notice Withdraw accumulated fees
      * @param to Address to send the fees to
      * @param amount Amount of fees to withdraw
-     * @dev Only the owner can call this function. Must be overridden in derived contracts
+     * @dev Only the operator can call this function. Must be overridden in derived contracts
      *      to perform the actual token/native transfer; base implementation reverts.
      */
     function withdrawFees(
         address to,
         uint256 amount
-    ) external virtual onlyOwner {
+    ) external virtual onlyOperator {
         if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
         if (amount > accumulatedFees) revert InsufficientAccumulatedFees();
@@ -241,10 +282,10 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable {
      * @notice Withdraw accumulated native COTI fees
      * @param to Address to send the native COTI fees to
      * @param amount Amount of native COTI fees to withdraw
-     * @dev Only the owner can call this function. Derived ERC20 bridges use this inherited implementation to withdraw
+     * @dev Only the operator can call this function. Derived ERC20 bridges use this inherited implementation to withdraw
      *      accumulated native COTI fees; native bridge does not use this (accumulatedCotiFees remains 0).
      */
-    function withdrawCotiFees(address to, uint256 amount) external onlyOwner {
+    function withdrawCotiFees(address to, uint256 amount) external onlyOperator {
         if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
         if (amount > accumulatedCotiFees) revert InsufficientAccumulatedFees();

--- a/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
+++ b/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
@@ -233,7 +233,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
     function withdrawFees(
         address to,
         uint256 amount
-    ) external override onlyOwner {
+    ) external override onlyOperator {
         if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
         if (amount > accumulatedFees) revert InsufficientAccumulatedFees();

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -223,7 +223,7 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
     function withdrawFees(
         address to,
         uint256 amount
-    ) external override onlyOwner {
+    ) external override onlyOperator {
         if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
         if (amount > accumulatedFees) revert InsufficientAccumulatedFees();


### PR DESCRIPTION
Strict isolated branch against latest upstream/development. Modifies PrivacyBridge, PrivacyBridgeCotiNative, and PrivacyBridgeERC20 to use OPERATOR_ROLE for the restricted fee/deposit config functions.