### PR TITLE
fix: privacy bridge security fixes

### DIFF
--- a/contracts/privacyBridge/PrivacyBridge.sol
+++ b/contracts/privacyBridge/PrivacyBridge.sol
@@ -20,8 +20,6 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
 
     event OperatorAdded(address indexed account, address indexed by);
     event OperatorRemoved(address indexed account, address indexed by);
-    event DepositEnabledUpdated(bool enabled, address indexed by);
-    event NativeCotiFeeUpdated(uint256 fee, address indexed by);
 
     /// @notice Maximum amount that can be deposited in a single transaction
     uint256 public maxDepositAmount;
@@ -50,8 +48,8 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     /// @notice Fee divisor (1,000,000)
     uint256 public constant FEE_DIVISOR = 1000000;
 
-    /// @notice Maximum fee allowed (10% = 100,000 units)
-    uint256 public constant MAX_FEE_UNITS = 100000;
+    /// @notice Maximum fee allowed (100% = 100,000 units)
+    uint256 public constant MAX_FEE_UNITS = 1000000;
 
     /// @notice Flag to enable/disable deposits
     bool public isDepositEnabled = true;
@@ -65,7 +63,6 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     error InvalidAddress();
     error DepositDisabled();
     error InsufficientCotiFee();
-    error BridgePaused();
 
     // Limits errors
     error InvalidLimitConfiguration();
@@ -75,7 +72,6 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     error WithdrawExceedsMaximum();
     error InvalidFee();
     error InsufficientAccumulatedFees();
-    error WithdrawFeesMustBeOverridden();
 
     /// @notice Emitted when a user deposits tokens
     /// @param user        Address of the user
@@ -100,8 +96,14 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     /// @notice Emitted when fees are updated
     event FeeUpdated(string feeType, uint256 newFeeBasisPoints);
 
+    /// @notice Emitted when deposit enabled state changes
+    event DepositEnabledUpdated(bool enabled);
+
     /// @notice Emitted when accumulated fees are withdrawn
     event FeesWithdrawn(address indexed to, uint256 amount);
+
+    /// @notice Emitted when accumulated native COTI fees are withdrawn
+    event CotiFeesWithdrawn(address indexed to, uint256 amount);
 
     constructor() Ownable() {
         maxDepositAmount = type(uint256).max;
@@ -139,12 +141,12 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
      */
     function transferOwnership(address newOwner) public override onlyOwner {
         if (newOwner == address(0)) revert InvalidAddress();
-        address oldOwner = owner();
+        address previousOwner = owner();
         super.transferOwnership(newOwner);
         _grantRole(DEFAULT_ADMIN_ROLE, newOwner);
         _grantRole(OPERATOR_ROLE, newOwner);
-        _revokeRole(DEFAULT_ADMIN_ROLE, oldOwner);
-        _revokeRole(OPERATOR_ROLE, oldOwner);
+        _revokeRole(DEFAULT_ADMIN_ROLE, previousOwner);
+        _revokeRole(OPERATOR_ROLE, previousOwner);
     }
 
     /**
@@ -214,8 +216,29 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     }
 
     /**
+     * @notice Validate all deposit pre-conditions
+     * @param amount The deposit amount to validate
+     * @dev Checks deposit-enabled flag, zero amount, and deposit limits
+     */
+    function _validateDeposit(uint256 amount) internal view {
+        if (!isDepositEnabled) revert DepositDisabled();
+        if (amount == 0) revert AmountZero();
+        _checkDepositLimits(amount);
+    }
+
+    /**
+     * @notice Validate all withdraw pre-conditions
+     * @param amount The withdrawal amount to validate
+     * @dev Checks zero amount and withdrawal limits
+     */
+    function _validateWithdraw(uint256 amount) internal view {
+        if (amount == 0) revert AmountZero();
+        _checkWithdrawLimits(amount);
+    }
+
+    /**
      * @notice Set the deposit fee
-     * @param _feeBasisPoints New deposit fee in fee units (max 100,000 = 10%)
+     * @param _feeBasisPoints New deposit fee in basis points (max 100,000 = 10%)
      * @dev Only the operator can call this function
      */
     function setDepositFee(uint256 _feeBasisPoints) external onlyOperator {
@@ -226,7 +249,7 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
 
     /**
      * @notice Set the withdrawal fee
-     * @param _feeBasisPoints New withdrawal fee in fee units (max 100,000 = 10%)
+     * @param _feeBasisPoints New withdrawal fee in basis points (max 10% = 100,000)
      * @dev Only the operator can call this function
      */
     function setWithdrawFee(uint256 _feeBasisPoints) external onlyOperator {
@@ -242,7 +265,7 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
      */
     function setIsDepositEnabled(bool _enabled) external onlyOperator {
         isDepositEnabled = _enabled;
-        emit DepositEnabledUpdated(_enabled, msg.sender);
+        emit DepositEnabledUpdated(_enabled);
     }
 
     /**
@@ -250,21 +273,10 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
      * @param _fee Amount in native tokens (wei-equivalent)
      * @dev Used by ERC20 bridges: they require msg.value >= this value and refund excess to the caller (best-effort). Only the operator can call this function.
      */
-    function setNativeCotiFee(uint256 _fee) external onlyOperator {
+    function setNativeCotiFee(uint256 _fee) external virtual onlyOperator {
         nativeCotiFee = _fee;
-        emit NativeCotiFeeUpdated(_fee, msg.sender);
+        emit FeeUpdated("nativeCoti", _fee);
     }
-
-    /**
-     * @notice Deposit preflight checks (for derived contracts)
-     * @dev Enforces pause state, deposit toggle, and amount limits.
-     */
-    function _preflightDeposit(uint256 amount) internal view {
-        if (paused()) revert BridgePaused();
-        if (!isDepositEnabled) revert DepositDisabled();
-        _checkDepositLimits(amount);
-    }
-
 
     /**
      * @notice Calculate fee amount based on the input amount and fee basis points
@@ -284,18 +296,12 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
      * @notice Withdraw accumulated fees
      * @param to Address to send the fees to
      * @param amount Amount of fees to withdraw
-     * @dev Only the operator can call this function. Must be overridden in derived contracts
-     *      to perform the actual token/native transfer; base implementation reverts.
+     * @dev Must be implemented by derived contracts to perform the actual transfer.
      */
     function withdrawFees(
         address to,
         uint256 amount
-    ) external virtual onlyOperator {
-        if (to == address(0)) revert InvalidAddress();
-        if (amount == 0) revert AmountZero();
-        if (amount > accumulatedFees) revert InsufficientAccumulatedFees();
-        revert WithdrawFeesMustBeOverridden();
-    }
+    ) external virtual;
 
     /**
      * @notice Withdraw accumulated native COTI fees
@@ -314,5 +320,7 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
 
         (bool success, ) = to.call{value: amount}("");
         if (!success) revert EthTransferFailed();
+
+        emit CotiFeesWithdrawn(to, amount);
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
+++ b/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
@@ -14,6 +14,9 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
     PrivateCOTI public privateCoti;
 
     error ExceedsRescueableAmount();
+    error NativeCotiFeeNotApplicable();
+
+    event NativeRescued(address indexed to, uint256 amount);
 
     // Scaling factor removed (using native 18 decimals due to uint256 upgrade)
 
@@ -35,10 +38,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
         bool isEncrypted,
         itUint256 memory encryptedAmount
     ) internal {
-        if (!isDepositEnabled) revert DepositDisabled();
-        if (msg.value == 0) revert AmountZero();
-
-        _checkDepositLimits(msg.value);
+        _validateDeposit(msg.value);
 
         // Calculate and deduct deposit fee
         uint256 feeAmount = _calculateFeeAmount(
@@ -104,9 +104,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
         bytes calldata
     ) external nonReentrant whenNotPaused returns (bool) {
         if (msg.sender != address(privateCoti)) revert InvalidAddress();
-        if (amount == 0) revert AmountZero();
-
-        _checkWithdrawLimits(amount);
+        _validateWithdraw(amount);
 
         // Calculate fee
         uint256 feeAmount = _calculateFeeAmount(amount, withdrawFeeBasisPoints);
@@ -160,8 +158,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
         bool isEncrypted,
         itUint256 memory encryptedAmount
     ) internal {
-        if (amount == 0) revert AmountZero();
-        _checkWithdrawLimits(amount);
+        _validateWithdraw(amount);
 
         // Calculate fee on the public side
         uint256 feeAmount = _calculateFeeAmount(amount, withdrawFeeBasisPoints);
@@ -182,20 +179,22 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
 
             // Use already-validated gt handle so PrivateCOTI does not re-call
             // validateCiphertext with a different contract context (signature mismatch)
-            IPrivateERC20(address(privateCoti)).transferFromGT(
+            gtBool transferOk = IPrivateERC20(address(privateCoti)).transferFromGT(
                 msg.sender,
                 address(this),
                 gtAmount
             );
+            require(MpcCore.decrypt(transferOk), "Transfer failed");
             gtBool burnOk = privateCoti.burnGt(gtAmount);
             require(MpcCore.decrypt(burnOk), "Burn failed");
         } else {
             // Standard withdrawal (public amount)
-            IPrivateERC20(address(privateCoti)).transferFrom(
+            bool transferOk = IPrivateERC20(address(privateCoti)).transferFrom(
                 msg.sender,
                 address(this),
                 amount
             );
+            require(transferOk, "Transfer failed");
             privateCoti.burn(amount);
         }
 
@@ -233,7 +232,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
     function withdrawFees(
         address to,
         uint256 amount
-    ) external override onlyOperator {
+    ) external override onlyOperator nonReentrant {
         if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
         if (amount > accumulatedFees) revert InsufficientAccumulatedFees();
@@ -257,7 +256,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
      * @param amount Amount of coins to rescue
      * @notice Only the owner can call this function
      */
-    function rescueNative(address to, uint256 amount) external onlyOwner {
+    function rescueNative(address to, uint256 amount) external onlyOwner nonReentrant {
         if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
         if (amount > address(this).balance) revert InsufficientEthBalance();
@@ -266,5 +265,15 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
 
         (bool success, ) = to.call{value: amount}("");
         if (!success) revert EthTransferFailed();
+
+        emit NativeRescued(to, amount);
+    }
+
+    /**
+     * @notice Set the native COTI fee
+     * @dev Native bridge does not use nativeCotiFee; always reverts.
+     */
+    function setNativeCotiFee(uint256) external pure override {
+        revert NativeCotiFeeNotApplicable();
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -7,12 +7,17 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "../token/PrivateERC20/IPrivateERC20.sol";
 import "../utils/mpc/MpcCore.sol";
 
+/// @dev Minimal interface to read decimals from tokens without modifying IPrivateERC20
+interface IHasDecimals {
+    function decimals() external view returns (uint8);
+}
+
 /**
  * @dev Abstract base contract for ERC20 Token Privacy Bridges
  * @dev Handles the logic for bridging ERC20 tokens to their private counterparts.
  * @dev The public ERC20 token must be standard (no fee-on-transfer, no rebasing); same decimals as private token.
  */
-contract PrivacyBridgeERC20 is PrivacyBridge {
+abstract contract PrivacyBridgeERC20 is PrivacyBridge {
     using SafeERC20 for IERC20;
 
     /// @notice The public ERC20 token being bridged (e.g., USDC, WETH)
@@ -31,6 +36,9 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
     error TokenTransferFailed();
     error InvalidTokenSender();
     error NativeFeeRequiredForTransferAndCallWithdraw();
+    error DecimalsMismatch();
+
+    event ERC20Rescued(address indexed token, address indexed to, uint256 amount);
 
     /**
      * @notice Initialize the PrivacyBridgeERC20 contract
@@ -40,6 +48,10 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
     constructor(address _token, address _privateToken) PrivacyBridge() {
         if (_token == address(0)) revert InvalidTokenAddress();
         if (_privateToken == address(0)) revert InvalidPrivateTokenAddress();
+
+        // Verify decimal parity to prevent silent exchange rate corruption
+        if (IHasDecimals(_token).decimals() != IHasDecimals(_privateToken).decimals())
+            revert DecimalsMismatch();
 
         token = IERC20(_token);
         privateToken = IPrivateERC20(_privateToken);
@@ -80,20 +92,20 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
         bool isEncrypted,
         itUint256 memory encryptedAmount
     ) internal {
-        if (!isDepositEnabled) revert DepositDisabled();
-        if (amount == 0) revert AmountZero();
+        _validateDeposit(amount);
         if (msg.value < nativeCotiFee) revert InsufficientCotiFee();
-
-        _checkDepositLimits(amount);
 
         // Handle native COTI fee (excess refunded to sender)
         accumulatedCotiFees += nativeCotiFee;
 
+        // Use balance-before/after to handle fee-on-transfer tokens correctly
+        uint256 balBefore = token.balanceOf(address(this));
         token.safeTransferFrom(msg.sender, address(this), amount);
+        uint256 received = token.balanceOf(address(this)) - balBefore;
 
-        // Calculate and deduct deposit fee (in tokens)
-        uint256 feeAmount = _calculateFeeAmount(amount, depositFeeBasisPoints);
-        uint256 amountAfterFee = amount - feeAmount;
+        // Calculate and deduct deposit fee based on actually received tokens
+        uint256 feeAmount = _calculateFeeAmount(received, depositFeeBasisPoints);
+        uint256 amountAfterFee = received - feeAmount;
         accumulatedFees += feeAmount;
 
         if (isEncrypted) {
@@ -112,15 +124,15 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
             require(mintOk, "Mint failed");
         }
 
-        // Emit gross deposit amount and net private tokens minted
-        emit Deposit(msg.sender, amount, amountAfterFee);
+        // Emit actual received amount (gross) and net private tokens minted
+        emit Deposit(msg.sender, received, amountAfterFee);
 
         // Refund excess native COTI fee (best-effort: do not revert so deposit succeeds even if sender cannot receive)
         if (msg.value > nativeCotiFee) {
             uint256 excess = msg.value - nativeCotiFee;
             (bool ok, ) = msg.sender.call{value: excess}("");
             if (!ok) {
-                // Excess remains in contract; deposit still succeeds
+                accumulatedCotiFees += excess; // excess unrefundable; make it recoverable via withdrawCotiFees
             }
         }
     }
@@ -158,9 +170,8 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
         bool isEncrypted,
         itUint256 memory encryptedAmount
     ) internal {
-        if (amount == 0) revert AmountZero();
+        _validateWithdraw(amount);
         if (msg.value < nativeCotiFee) revert InsufficientCotiFee();
-        _checkWithdrawLimits(amount);
 
         // Handle native COTI fee (excess refunded to sender)
         accumulatedCotiFees += nativeCotiFee;
@@ -171,7 +182,7 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
         accumulatedFees += feeAmount;
 
         uint256 bridgeBalance = token.balanceOf(address(this));
-        if (bridgeBalance < amountAfterFee)
+        if (bridgeBalance < accumulatedFees + amountAfterFee)
             revert InsufficientBridgeLiquidity();
 
         if (isEncrypted) {
@@ -195,7 +206,8 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
             require(MpcCore.decrypt(burnOk), "Burn failed");
         } else {
             // Standard withdrawal (public amount)
-            privateToken.transferFrom(msg.sender, address(this), amount);
+            bool transferOk = privateToken.transferFrom(msg.sender, address(this), amount);
+            require(transferOk, "Transfer failed");
             privateToken.burn(amount);
         }
 
@@ -209,7 +221,7 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
             uint256 excess = msg.value - nativeCotiFee;
             (bool ok, ) = msg.sender.call{value: excess}("");
             if (!ok) {
-                // Excess remains in contract; withdraw still succeeds
+                accumulatedCotiFees += excess; // excess unrefundable; make it recoverable via withdrawCotiFees
             }
         }
     }
@@ -243,7 +255,7 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
         address _token,
         address to,
         uint256 amount
-    ) external onlyOwner {
+    ) external onlyOwner nonReentrant {
         if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
         
@@ -251,5 +263,7 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
             revert CannotRescueBridgeToken();
 
         IERC20(_token).safeTransfer(to, amount);
+
+        emit ERC20Rescued(_token, to, amount);
     }
 }


### PR DESCRIPTION
## Summary

Security fixes for `PrivacyBridge`, `PrivacyBridgeCotiNative`, and `PrivacyBridgeERC20`.

## Changes

**H-3** — Fee accounting inconsistency in `PrivacyBridgeERC20._withdraw`: liquidity check now subtracts `accumulatedFees` to prevent fee reserve from being raided by user withdrawals.

**M-5** — `setIsDepositEnabled` now emits `DepositEnabledUpdated` event for off-chain observability.

**L-6** — Constructor validates decimal parity between public and private tokens via `IHasDecimals` interface, reverting with `DecimalsMismatch` on mismatch.

**C-1** — `PrivacyBridgeCotiNative.withdrawFees` now has `nonReentrant` guard, consistent with `withdrawCotiFees` and closing cross-function reentrancy window against `rescueNative`.

**H-4** — Unrefundable native fee excess (failed best-effort refund) is now added to `accumulatedCotiFees`, making it recoverable via `withdrawCotiFees` instead of being permanently stranded.

**L-5** — `rescueNative` and `rescueERC20` now have `nonReentrant` guards against malicious recipient contracts and non-standard ERC20 callbacks.

**Return value checks** — All `transferFrom` and `transferFromGT` calls in withdraw paths now check return values, preventing fund drain if the private token returns `false` instead of reverting.

**Events** — `setNativeCotiFee` reuses `FeeUpdated`, `rescueNative` emits `NativeRescued`, `rescueERC20` emits `ERC20Rescued` for full off-chain observability of privileged actions.

**L-01]** - Fee-on-transfer protection (
PrivacyBridgeERC20.sol
 _deposit) — Added a balance-before/after check around safeTransferFrom so fee calculation, minting, and event emission use the actual received amount instead of the requested amount. Prevents under-collateralization with non-standard ERC20s.

**L-06** - Missing event in withdrawCotiFees (
PrivacyBridge.sol
) — Added event CotiFeesWithdrawn(address indexed to, uint256 amount) and emitted it at the end of withdrawCotiFees for off-chain tracking parity with withdrawFees.

**I-03** -  PrivacyBridgeERC20 marked abstract (
PrivacyBridgeERC20.sol
) — Changed contract to abstract contract to match the NatSpec and prevent standalone deployment. Verified 7 child contracts inherit from it safely.
