### PR TITLE
fix: Privacy Bridge security audit fixes

### DIFF
--- a/contracts/privacyBridge/PrivacyBridge.sol
+++ b/contracts/privacyBridge/PrivacyBridge.sol
@@ -50,8 +50,8 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     /// @notice Fee divisor (1,000,000)
     uint256 public constant FEE_DIVISOR = 1000000;
 
-    /// @notice Maximum fee allowed (10% = 100,000 units)
-    uint256 public constant MAX_FEE_UNITS = 100000;
+    /// @notice Maximum fee allowed (100% = 1,000,000 units)
+    uint256 public constant MAX_FEE_UNITS = 1000000;
 
     /// @notice Flag to enable/disable deposits
     bool public isDepositEnabled = true;
@@ -145,6 +145,14 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
         _grantRole(OPERATOR_ROLE, newOwner);
         _revokeRole(DEFAULT_ADMIN_ROLE, oldOwner);
         _revokeRole(OPERATOR_ROLE, oldOwner);
+    }
+
+    /**
+     * @dev Disabled to prevent split-brain state between Ownable and AccessControl.
+     *      Use transferOwnership instead.
+     */
+    function renounceOwnership() public override onlyOwner {
+        revert("renounceOwnership disabled");
     }
 
     /**
@@ -250,19 +258,9 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
      * @param _fee Amount in native tokens (wei-equivalent)
      * @dev Used by ERC20 bridges: they require msg.value >= this value and refund excess to the caller (best-effort). Only the operator can call this function.
      */
-    function setNativeCotiFee(uint256 _fee) external onlyOperator {
+    function setNativeCotiFee(uint256 _fee) external virtual onlyOperator {
         nativeCotiFee = _fee;
         emit NativeCotiFeeUpdated(_fee, msg.sender);
-    }
-
-    /**
-     * @notice Deposit preflight checks (for derived contracts)
-     * @dev Enforces pause state, deposit toggle, and amount limits.
-     */
-    function _preflightDeposit(uint256 amount) internal view {
-        if (paused()) revert BridgePaused();
-        if (!isDepositEnabled) revert DepositDisabled();
-        _checkDepositLimits(amount);
     }
 
 
@@ -297,6 +295,8 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
         revert WithdrawFeesMustBeOverridden();
     }
 
+    event CotiFeesWithdrawn(address indexed to, uint256 amount);
+
     /**
      * @notice Withdraw accumulated native COTI fees
      * @param to Address to send the native COTI fees to
@@ -314,5 +314,7 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
 
         (bool success, ) = to.call{value: amount}("");
         if (!success) revert EthTransferFailed();
+
+        emit CotiFeesWithdrawn(to, amount);
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
+++ b/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
@@ -14,6 +14,9 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
     PrivateCOTI public privateCoti;
 
     error ExceedsRescueableAmount();
+    error NativeCotiFeeNotApplicable();
+
+    event NativeRescued(address indexed to, uint256 amount);
 
     // Scaling factor removed (using native 18 decimals due to uint256 upgrade)
 
@@ -46,6 +49,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
             depositFeeBasisPoints
         );
         uint256 amountAfterFee = msg.value - feeAmount;
+        if (amountAfterFee == 0) revert AmountZero();
         accumulatedFees += feeAmount;
 
         if (isEncrypted) {
@@ -110,6 +114,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
         // Calculate fee
         uint256 feeAmount = _calculateFeeAmount(amount, withdrawFeeBasisPoints);
         uint256 publicAmount = amount - feeAmount;
+        if (publicAmount == 0) revert AmountZero();
         accumulatedFees += feeAmount;
 
         if (address(this).balance < publicAmount)
@@ -165,6 +170,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
         // Calculate fee on the public side
         uint256 feeAmount = _calculateFeeAmount(amount, withdrawFeeBasisPoints);
         uint256 publicAmount = amount - feeAmount;
+        if (publicAmount == 0) revert AmountZero();
         accumulatedFees += feeAmount;
 
         if (address(this).balance < publicAmount)
@@ -231,7 +237,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
     function withdrawFees(
         address to,
         uint256 amount
-    ) external override onlyOperator {
+    ) external override onlyOperator nonReentrant {
         if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
         if (amount > accumulatedFees) revert InsufficientAccumulatedFees();
@@ -255,7 +261,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
      * @param amount Amount of coins to rescue
      * @notice Only the owner can call this function
      */
-    function rescueNative(address to, uint256 amount) external onlyOwner {
+    function rescueNative(address to, uint256 amount) external onlyOwner nonReentrant {
         if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
         if (amount > address(this).balance) revert InsufficientEthBalance();
@@ -264,5 +270,14 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
 
         (bool success, ) = to.call{value: amount}("");
         if (!success) revert EthTransferFailed();
+
+        emit NativeRescued(to, amount);
+    }
+
+    /**
+     * @notice Native bridge does not use nativeCotiFee; always reverts.
+     */
+    function setNativeCotiFee(uint256) external pure override {
+        revert NativeCotiFeeNotApplicable();
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -7,12 +7,17 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "../token/PrivateERC20/IPrivateERC20.sol";
 import "../utils/mpc/MpcCore.sol";
 
+/// @dev Minimal interface to read decimals from tokens without modifying IPrivateERC20
+interface IHasDecimals {
+    function decimals() external view returns (uint8);
+}
+
 /**
  * @dev Abstract base contract for ERC20 Token Privacy Bridges
  * @dev Handles the logic for bridging ERC20 tokens to their private counterparts.
  * @dev The public ERC20 token must be standard (no fee-on-transfer, no rebasing); same decimals as private token.
  */
-contract PrivacyBridgeERC20 is PrivacyBridge {
+abstract contract PrivacyBridgeERC20 is PrivacyBridge {
     using SafeERC20 for IERC20;
 
     /// @notice The public ERC20 token being bridged (e.g., USDC, WETH)
@@ -31,6 +36,9 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
     error TokenTransferFailed();
     error InvalidTokenSender();
     error NativeFeeRequiredForTransferAndCallWithdraw();
+    error DecimalsMismatch();
+
+    event ERC20Rescued(address indexed token, address indexed to, uint256 amount);
 
     /**
      * @notice Initialize the PrivacyBridgeERC20 contract
@@ -40,6 +48,10 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
     constructor(address _token, address _privateToken) PrivacyBridge() {
         if (_token == address(0)) revert InvalidTokenAddress();
         if (_privateToken == address(0)) revert InvalidPrivateTokenAddress();
+
+        // Verify decimal parity to prevent silent exchange rate corruption
+        if (IHasDecimals(_token).decimals() != IHasDecimals(_privateToken).decimals())
+            revert DecimalsMismatch();
 
         token = IERC20(_token);
         privateToken = IPrivateERC20(_privateToken);
@@ -89,11 +101,15 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
         // Handle native COTI fee (excess refunded to sender)
         accumulatedCotiFees += nativeCotiFee;
 
+        // Use balance-before/after to handle fee-on-transfer tokens correctly
+        uint256 balBefore = token.balanceOf(address(this));
         token.safeTransferFrom(msg.sender, address(this), amount);
+        uint256 received = token.balanceOf(address(this)) - balBefore;
 
-        // Calculate and deduct deposit fee (in tokens)
-        uint256 feeAmount = _calculateFeeAmount(amount, depositFeeBasisPoints);
-        uint256 amountAfterFee = amount - feeAmount;
+        // Calculate and deduct deposit fee based on actually received tokens
+        uint256 feeAmount = _calculateFeeAmount(received, depositFeeBasisPoints);
+        uint256 amountAfterFee = received - feeAmount;
+        if (amountAfterFee == 0) revert AmountZero();
         accumulatedFees += feeAmount;
 
         if (isEncrypted) {
@@ -110,15 +126,15 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
             privateToken.mint(msg.sender, amountAfterFee);
         }
 
-        // Emit gross deposit amount and net private tokens minted
-        emit Deposit(msg.sender, amount, amountAfterFee);
+        // Emit actual received amount (gross) and net private tokens minted
+        emit Deposit(msg.sender, received, amountAfterFee);
 
         // Refund excess native COTI fee (best-effort: do not revert so deposit succeeds even if sender cannot receive)
         if (msg.value > nativeCotiFee) {
             uint256 excess = msg.value - nativeCotiFee;
             (bool ok, ) = msg.sender.call{value: excess}("");
             if (!ok) {
-                // Excess remains in contract; deposit still succeeds
+                accumulatedCotiFees += excess; // excess unrefundable; make it recoverable via withdrawCotiFees
             }
         }
     }
@@ -166,10 +182,11 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
         // Calculate fee on the public side
         uint256 feeAmount = _calculateFeeAmount(amount, withdrawFeeBasisPoints);
         uint256 amountAfterFee = amount - feeAmount;
+        if (amountAfterFee == 0) revert AmountZero();
         accumulatedFees += feeAmount;
 
         uint256 bridgeBalance = token.balanceOf(address(this));
-        if (bridgeBalance < amountAfterFee)
+        if (bridgeBalance < accumulatedFees + amountAfterFee)
             revert InsufficientBridgeLiquidity();
 
         if (isEncrypted) {
@@ -219,7 +236,7 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
     function withdrawFees(
         address to,
         uint256 amount
-    ) external override onlyOperator {
+    ) external override onlyOperator nonReentrant {
         if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
         if (amount > accumulatedFees) revert InsufficientAccumulatedFees();
@@ -239,7 +256,7 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
         address _token,
         address to,
         uint256 amount
-    ) external onlyOwner {
+    ) external onlyOwner nonReentrant {
         if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
         
@@ -247,5 +264,7 @@ contract PrivacyBridgeERC20 is PrivacyBridge {
             revert CannotRescueBridgeToken();
 
         IERC20(_token).safeTransfer(to, amount);
+
+        emit ERC20Rescued(_token, to, amount);
     }
 }


### PR DESCRIPTION
## Security Audit Fixes for PrivacyBridge Contracts

### Critical / High
- **M-5**: `_withdraw` liquidity check now accounts for `accumulatedFees`, preventing fee reserve drain
- **H-1/H-2/H-3**: Added `nonReentrant` to `withdrawFees` and `rescue*` functions across both bridges
- **H-4**: Zero-amount mint/withdraw after fee deduction now reverts with `AmountZero`
- **H-5**: Unrefundable native fee excess in `_deposit` added to `accumulatedCotiFees` (recoverable via `withdrawCotiFees`)

### Medium
- **M-3**: `setNativeCotiFee` overridden in `PrivacyBridgeCotiNative` to revert with `NativeCotiFeeNotApplicable`
- **M-4**: Removed dead code `_preflightDeposit` from base contract
- **M-6**: (noted, not addressed in this PR — `rescueERC20` should also block `address(token)`)
- **MAX_FEE_UNITS** raised from 100,000 (10%) to 1,000,000 (100%) per business requirement

### Low / Informational
- **L-1**: `renounceOwnership` disabled to prevent Ownable/AccessControl split-brain state
- **L-2/Events**: Added `NativeRescued`, `ERC20Rescued`, `CotiFeesWithdrawn` events for off-chain observability
- **L-4**: Fee-on-transfer protection via balance-before/after pattern in ERC20 `_deposit`
- **I-2**: Constructor decimal parity check between public and private tokens (`DecimalsMismatch`)
- **I-3**: `PrivacyBridgeERC20` marked `abstract` to prevent standalone deployment

### Files Changed
- `contracts/privacyBridge/PrivacyBridge.sol`
- `contracts/privacyBridge/PrivacyBridgeCotiNative.sol`
- `contracts/privacyBridge/PrivacyBridgeERC20.sol`