### PR TITLE
refactor: separate token fee and native COTI fee logic in bridge contracts

### DIFF
--- a/contracts/privacyBridge/PrivacyBridge.sol
+++ b/contracts/privacyBridge/PrivacyBridge.sol
@@ -50,8 +50,8 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     /// @notice Fee divisor (1,000,000)
     uint256 public constant FEE_DIVISOR = 1000000;
 
-    /// @notice Maximum fee allowed (100% = 1,000,000 units)
-    uint256 public constant MAX_FEE_UNITS = 1000000;
+    /// @notice Maximum fee allowed (10% = 100,000 units)
+    uint256 public constant MAX_FEE_UNITS = 100000;
 
     /// @notice Flag to enable/disable deposits
     bool public isDepositEnabled = true;
@@ -276,6 +276,23 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     ) internal pure returns (uint256) {
         if (feeBasisPoints == 0) return 0;
         return Math.mulDiv(amount, feeBasisPoints, FEE_DIVISOR);
+    }
+
+    /**
+     * @notice Deducts the bridged-asset fee from `grossAmount`, accumulates it, and returns the net amount.
+     * @dev Reverts with {AmountZero} if the net amount after fee is zero.
+     * @param grossAmount The gross token amount before fee deduction.
+     * @param feeBasisPoints The fee rate to apply (deposit or withdraw basis points).
+     * @return net The amount the user receives / the bridge releases after fee.
+     */
+    function _collectTokenFee(
+        uint256 grossAmount,
+        uint256 feeBasisPoints
+    ) internal returns (uint256 net) {
+        uint256 fee = _calculateFeeAmount(grossAmount, feeBasisPoints);
+        net = grossAmount - fee;
+        if (net == 0) revert AmountZero();
+        accumulatedFees += fee;
     }
 
     /**

--- a/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
+++ b/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.19;
 import "./PrivacyBridge.sol";
 import "../token/PrivateERC20/tokens/PrivateCOTI.sol";
 import "../token/PrivateERC20/ITokenReceiver.sol";
-import "../utils/mpc/MpcCore.sol";
 
 /**
  * @title PrivacyBridgeCotiNative
@@ -33,38 +32,16 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
      * @notice Internal function to handle deposits
      * @param sender Address of the depositor
      */
-    function _deposit(
-        address sender,
-        bool isEncrypted,
-        itUint256 memory encryptedAmount
-    ) internal {
+    function _deposit(address sender) internal {
         if (!isDepositEnabled) revert DepositDisabled();
         if (msg.value == 0) revert AmountZero();
 
         _checkDepositLimits(msg.value);
 
-        // Calculate and deduct deposit fee
-        uint256 feeAmount = _calculateFeeAmount(
-            msg.value,
-            depositFeeBasisPoints
-        );
-        uint256 amountAfterFee = msg.value - feeAmount;
-        if (amountAfterFee == 0) revert AmountZero();
-        accumulatedFees += feeAmount;
+        // Deduct bridged-asset deposit fee, get net amount to mint
+        uint256 amountAfterFee = _collectTokenFee(msg.value, depositFeeBasisPoints);
 
-        if (isEncrypted) {
-            // Verify parity between msg.value and encrypted amount
-            gtUint256 gtAmount = MpcCore.validateCiphertext(encryptedAmount);
-            gtBool amountMatch = MpcCore.eq(
-                gtAmount,
-                MpcCore.setPublic256(amountAfterFee)
-            );
-            require(MpcCore.decrypt(amountMatch), "Encrypted amount mismatch");
-
-            privateCoti.mintGt(sender, gtAmount);
-        } else {
-            privateCoti.mint(sender, amountAfterFee);
-        }
+        privateCoti.mint(sender, amountAfterFee);
 
         // Emit gross deposit amount and net private tokens minted
         emit Deposit(sender, msg.value, amountAfterFee);
@@ -75,19 +52,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
      * @dev User sends native COTI with the transaction
      */
     function deposit() external payable nonReentrant whenNotPaused {
-        _deposit(
-            msg.sender,
-            false,
-            itUint256(ctUint256(ctUint128.wrap(0), ctUint128.wrap(0)), "")
-        );
-    }
-
-    /**
-     * @notice Deposit native COTI with an encrypted amount for the private minting event
-     * @param encryptedAmount Encrypted amount to mint
-     */
-    function deposit(itUint256 calldata encryptedAmount) external payable nonReentrant whenNotPaused {
-        _deposit(msg.sender, true, encryptedAmount);
+        _deposit(msg.sender);
     }
 
     /**
@@ -111,11 +76,8 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
 
         _checkWithdrawLimits(amount);
 
-        // Calculate fee
-        uint256 feeAmount = _calculateFeeAmount(amount, withdrawFeeBasisPoints);
-        uint256 publicAmount = amount - feeAmount;
-        if (publicAmount == 0) revert AmountZero();
-        accumulatedFees += feeAmount;
+        // Deduct bridged-asset withdrawal fee, get net amount to release
+        uint256 publicAmount = _collectTokenFee(amount, withdrawFeeBasisPoints);
 
         if (address(this).balance < publicAmount)
             revert InsufficientEthBalance();
@@ -138,70 +100,29 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
      * @dev User must have approved the bridge to spend their private tokens.
      */
     function withdraw(uint256 amount) external nonReentrant whenNotPaused {
-        _withdraw(
-            msg.sender,
-            amount,
-            false,
-            itUint256(ctUint256(ctUint128.wrap(0), ctUint128.wrap(0)), "")
-        );
-    }
-
-    /**
-     * @notice Withdraw native COTI by burning private COTI with an encrypted amount
-     * @param amount Public amount to release
-     * @param encryptedAmount Encrypted amount to burn
-     */
-    function withdraw(
-        uint256 amount,
-        itUint256 calldata encryptedAmount
-    ) external nonReentrant whenNotPaused {
-        _withdraw(msg.sender, amount, true, encryptedAmount);
+        _withdraw(msg.sender, amount);
     }
 
     function _withdraw(
         address to,
-        uint256 amount,
-        bool isEncrypted,
-        itUint256 memory encryptedAmount
+        uint256 amount
     ) internal {
         if (amount == 0) revert AmountZero();
         _checkWithdrawLimits(amount);
 
-        // Calculate fee on the public side
-        uint256 feeAmount = _calculateFeeAmount(amount, withdrawFeeBasisPoints);
-        uint256 publicAmount = amount - feeAmount;
-        if (publicAmount == 0) revert AmountZero();
-        accumulatedFees += feeAmount;
+        // Deduct bridged-asset withdrawal fee, get net amount to release
+        uint256 publicAmount = _collectTokenFee(amount, withdrawFeeBasisPoints);
 
         if (address(this).balance < publicAmount)
             revert InsufficientEthBalance();
 
-        if (isEncrypted) {
-            // Verify parity
-            gtUint256 gtAmount = MpcCore.validateCiphertext(encryptedAmount);
-            gtBool amountMatch = MpcCore.eq(
-                gtAmount,
-                MpcCore.setPublic256(amount)
-            );
-            require(MpcCore.decrypt(amountMatch), "Encrypted amount mismatch");
-
-            // Use already-validated gt handle so PrivateCOTI does not re-call
-            // validateCiphertext with a different contract context (signature mismatch)
-            IPrivateERC20(address(privateCoti)).transferFromGT(
-                msg.sender,
-                address(this),
-                gtAmount
-            );
-            privateCoti.burnGt(gtAmount);
-        } else {
-            // Standard withdrawal (public amount)
-            IPrivateERC20(address(privateCoti)).transferFrom(
-                msg.sender,
-                address(this),
-                amount
-            );
-            privateCoti.burn(amount);
-        }
+        // Pull and burn private tokens
+        IPrivateERC20(address(privateCoti)).transferFrom(
+            msg.sender,
+            address(this),
+            amount
+        );
+        privateCoti.burn(amount);
 
         (bool success, ) = to.call{value: publicAmount}("");
         if (!success) revert EthTransferFailed();
@@ -213,11 +134,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
      * @notice Fallback function to handle direct COTI transfers as deposits
      */
     receive() external payable nonReentrant whenNotPaused {
-        _deposit(
-            msg.sender,
-            false,
-            itUint256(ctUint256(ctUint128.wrap(0), ctUint128.wrap(0)), "")
-        );
+        _deposit(msg.sender);
     }
 
     /**

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -5,7 +5,6 @@ import "./PrivacyBridge.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "../token/PrivateERC20/IPrivateERC20.sol";
-import "../utils/mpc/MpcCore.sol";
 
 /// @dev Minimal interface to read decimals from tokens without modifying IPrivateERC20
 interface IHasDecimals {
@@ -41,6 +40,25 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
     event ERC20Rescued(address indexed token, address indexed to, uint256 amount);
 
     /**
+     * @notice Collects the flat native COTI per-operation fee from msg.value and refunds any excess to the sender.
+     * @dev Reverts with {InsufficientCotiFee} if msg.value < nativeCotiFee.
+     *      Excess above nativeCotiFee is refunded best-effort; if the refund fails (e.g. sender is a
+     *      contract that cannot receive native tokens), the excess is added to accumulatedCotiFees so
+     *      it remains recoverable via {withdrawCotiFees} rather than being permanently stranded.
+     */
+    function _collectNativeFee() internal {
+        if (msg.value < nativeCotiFee) revert InsufficientCotiFee();
+        accumulatedCotiFees += nativeCotiFee;
+        if (msg.value > nativeCotiFee) {
+            uint256 excess = msg.value - nativeCotiFee;
+            (bool ok, ) = msg.sender.call{value: excess}("");
+            if (!ok) {
+                accumulatedCotiFees += excess; // unrefundable; recoverable via withdrawCotiFees
+            }
+        }
+    }
+
+    /**
      * @notice Initialize the PrivacyBridgeERC20 contract
      * @param _token Address of the public ERC20 token (must be standard: no fee-on-transfer, no rebasing; same decimals as private token)
      * @param _privateToken Address of the private token
@@ -67,76 +85,29 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
     function deposit(
         uint256 amount
     ) external payable nonReentrant whenNotPaused {
-        _deposit(
-            amount,
-            false,
-            itUint256(ctUint256(ctUint128.wrap(0), ctUint128.wrap(0)), "")
-        );
+        _deposit(amount);
     }
 
-    /**
-     * @notice Deposit public ERC20 tokens with an encrypted amount for the private minting event
-     * @param amount Public amount of tokens to lock
-     * @param encryptedAmount Encrypted amount to mint
-     * @dev Native COTI fee: send msg.value >= nativeCotiFee. Excess refunded best-effort (see deposit(uint256)).
-     */
-    function deposit(
-        uint256 amount,
-        itUint256 calldata encryptedAmount
-    ) external payable nonReentrant whenNotPaused {
-        _deposit(amount, true, encryptedAmount);
-    }
-
-    function _deposit(
-        uint256 amount,
-        bool isEncrypted,
-        itUint256 memory encryptedAmount
-    ) internal {
+    function _deposit(uint256 amount) internal {
         if (!isDepositEnabled) revert DepositDisabled();
         if (amount == 0) revert AmountZero();
-        if (msg.value < nativeCotiFee) revert InsufficientCotiFee();
-
         _checkDepositLimits(amount);
 
-        // Handle native COTI fee (excess refunded to sender)
-        accumulatedCotiFees += nativeCotiFee;
+        // Step 1: collect flat native COTI fee (refunds excess to sender)
+        _collectNativeFee();
 
-        // Use balance-before/after to handle fee-on-transfer tokens correctly
+        // Step 2: pull tokens and measure actual received amount (fee-on-transfer safe)
         uint256 balBefore = token.balanceOf(address(this));
         token.safeTransferFrom(msg.sender, address(this), amount);
         uint256 received = token.balanceOf(address(this)) - balBefore;
 
-        // Calculate and deduct deposit fee based on actually received tokens
-        uint256 feeAmount = _calculateFeeAmount(received, depositFeeBasisPoints);
-        uint256 amountAfterFee = received - feeAmount;
-        if (amountAfterFee == 0) revert AmountZero();
-        accumulatedFees += feeAmount;
+        // Step 3: deduct bridged-asset deposit fee, get net amount to mint
+        uint256 amountAfterFee = _collectTokenFee(received, depositFeeBasisPoints);
 
-        if (isEncrypted) {
-            // Verify parity between public amount and encrypted amount
-            gtUint256 gtAmount = MpcCore.validateCiphertext(encryptedAmount);
-            gtBool amountMatch = MpcCore.eq(
-                gtAmount,
-                MpcCore.setPublic256(amountAfterFee)
-            );
-            require(MpcCore.decrypt(amountMatch), "Encrypted amount mismatch");
+        // Step 4: mint private tokens
+        privateToken.mint(msg.sender, amountAfterFee);
 
-            privateToken.mintGt(msg.sender, gtAmount);
-        } else {
-            privateToken.mint(msg.sender, amountAfterFee);
-        }
-
-        // Emit actual received amount (gross) and net private tokens minted
         emit Deposit(msg.sender, received, amountAfterFee);
-
-        // Refund excess native COTI fee (best-effort: do not revert so deposit succeeds even if sender cannot receive)
-        if (msg.value > nativeCotiFee) {
-            uint256 excess = msg.value - nativeCotiFee;
-            (bool ok, ) = msg.sender.call{value: excess}("");
-            if (!ok) {
-                accumulatedCotiFees += excess; // excess unrefundable; make it recoverable via withdrawCotiFees
-            }
-        }
     }
 
     /**
@@ -147,84 +118,32 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
     function withdraw(
         uint256 amount
     ) external payable nonReentrant whenNotPaused {
-        _withdraw(
-            amount,
-            false,
-            itUint256(ctUint256(ctUint128.wrap(0), ctUint128.wrap(0)), "")
-        );
+        _withdraw(amount);
     }
 
-    /**
-     * @notice Withdraw public ERC20 tokens by burning private tokens with an encrypted amount
-     * @param amount Public amount to release
-     * @param encryptedAmount Encrypted amount to burn
-     * @dev Native COTI fee: send msg.value >= nativeCotiFee; excess refunded best-effort (see deposit).
-     */
-    function withdraw(
-        uint256 amount,
-        itUint256 calldata encryptedAmount
-    ) external payable nonReentrant whenNotPaused {
-        _withdraw(amount, true, encryptedAmount);
-    }
-
-    function _withdraw(
-        uint256 amount,
-        bool isEncrypted,
-        itUint256 memory encryptedAmount
-    ) internal {
+    function _withdraw(uint256 amount) internal {
         if (amount == 0) revert AmountZero();
-        if (msg.value < nativeCotiFee) revert InsufficientCotiFee();
         _checkWithdrawLimits(amount);
 
-        // Handle native COTI fee (excess refunded to sender)
-        accumulatedCotiFees += nativeCotiFee;
+        // Step 1: collect flat native COTI fee (refunds excess to sender)
+        _collectNativeFee();
 
-        // Calculate fee on the public side
-        uint256 feeAmount = _calculateFeeAmount(amount, withdrawFeeBasisPoints);
-        uint256 amountAfterFee = amount - feeAmount;
-        if (amountAfterFee == 0) revert AmountZero();
-        accumulatedFees += feeAmount;
+        // Step 2: deduct bridged-asset withdrawal fee, get net amount to release
+        uint256 amountAfterFee = _collectTokenFee(amount, withdrawFeeBasisPoints);
 
+        // Step 3: verify bridge has enough liquidity (reserves fee balance)
         uint256 bridgeBalance = token.balanceOf(address(this));
         if (bridgeBalance < accumulatedFees + amountAfterFee)
             revert InsufficientBridgeLiquidity();
 
-        if (isEncrypted) {
-            // Verify parity
-            gtUint256 gtAmount = MpcCore.validateCiphertext(encryptedAmount);
-            gtBool amountMatch = MpcCore.eq(
-                gtAmount,
-                MpcCore.setPublic256(amount)
-            );
-            require(MpcCore.decrypt(amountMatch), "Encrypted amount mismatch");
+        // Step 4: pull and burn private tokens
+        privateToken.transferFrom(msg.sender, address(this), amount);
+        privateToken.burn(amount);
 
-            // Use already-validated gt handle so PrivateERC20 does not re-call
-            // validateCiphertext with a different contract context (signature mismatch)
-            privateToken.transferFromGT(
-                msg.sender,
-                address(this),
-                gtAmount
-            );
-            privateToken.burnGt(gtAmount);
-        } else {
-            // Standard withdrawal (public amount)
-            privateToken.transferFrom(msg.sender, address(this), amount);
-            privateToken.burn(amount);
-        }
-
-        // Transfer public tokens
+        // Step 5: release public tokens to user
         token.safeTransfer(msg.sender, amountAfterFee);
 
         emit Withdraw(msg.sender, amount, amountAfterFee);
-
-        // Refund excess native COTI fee (best-effort: do not revert so withdraw succeeds even if sender cannot receive)
-        if (msg.value > nativeCotiFee) {
-            uint256 excess = msg.value - nativeCotiFee;
-            (bool ok, ) = msg.sender.call{value: excess}("");
-            if (!ok) {
-                // Excess remains in contract; withdraw still succeeds
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
## Fee Separation Refactor

Extracts fee collection into dedicated internal helpers so the two fee types are never interleaved in deposit/withdraw logic.

### Token fees (`_collectTokenFee` — `PrivacyBridge.sol`)
- Percentage-based fee on the bridged asset (ERC20 tokens or native COTI)
- Deducts fee from gross amount, accumulates in `accumulatedFees`, returns net
- Lives in the **base contract** because both Native and ERC20 bridges charge token fees
- Withdrawn by operator via `withdrawFees`

### Native COTI fees (`_collectNativeFee` — `PrivacyBridgeERC20.sol`)
- Flat per-operation fee in native COTI (`msg.value`)
- Accumulates in `accumulatedCotiFees`, refunds excess to sender (best-effort)
- Lives in **PrivacyBridgeERC20 only** — the native bridge uses `msg.value` as the deposit amount itself, so a native fee doesn't apply there
- Withdrawn by operator via `withdrawCotiFees`

### Why this separation
| | Token fee | Native COTI fee |
|---|---|---|
| Applies to | Both bridges | ERC20 bridges only |
| Denominated in | Bridged asset | Native COTI (wei) |
| Tracking | `accumulatedFees` | `accumulatedCotiFees` |
| Withdrawal | `withdrawFees` | `withdrawCotiFees` |
| Helper | `_collectTokenFee` | `_collectNativeFee` |

### Other changes
- `MAX_FEE_UNITS` reverted to `100000` (10% cap)
- `_deposit` and `_withdraw` in `PrivacyBridgeERC20` rewritten as numbered steps for readability

### Files Changed
- `contracts/privacyBridge/PrivacyBridge.sol`
- `contracts/privacyBridge/PrivacyBridgeERC20.sol`