### PR TITLE
feat: add deploy scripts for privacy bridge

### DIFF
--- a/deploy/privacy_bridge/config.ts
+++ b/deploy/privacy_bridge/config.ts
@@ -1,0 +1,3096 @@
+export const CONTRACT_ADDRESSES = {
+    // COTI Testnet
+    7082400: {
+    // Native
+    PrivateCoti: "0x4F25145dDAe730B86De8b7e583c728c42EA6b252",
+    PrivacyBridgeCotiNative: "0xbdF0769121E8900F2CD0C372279F5Ba4723C4482",
+
+    // Public Tokens
+    WETH: "0x8bca4e6bbE402DB4aD189A316137aD08206154FB",
+    WBTC: "0x5dBDb2E5D51c3FFab5D6B862Caa11FCe1D83F492",
+    USDT: "0x9e961430053cd5AbB3b060544cEcCec848693Cf0",
+    USDC_E: "0x63f3D2Cc8F5608F57ce6E5Aa3590A2Beb428D19C",
+    WADA: "0xe3E2cd3Abf412c73a404b9b8227B71dE3CfE829D",
+    gCOTI: "0x878a42D3cB737DEC9E6c7e7774d973F46fd8ed4C",
+
+    // Private Tokens
+    "p.WETH": "0x2BE7a34d141a5876c901d44Ec4Bcd8eDda2EF1d9",
+    "p.WBTC": "0x082133B7D4Bf0Ccb6d0c63a52fE9166565d25687",
+    "p.USDT": "0x998ee6df733FaaC9e3D41E5B95AADCDb3422E5CE",
+    "p.USDC_E": "0x66685E1629B7615834b636278198a25b9E060235",
+    "p.WADA": "0x43d6dd2508170772E265d9e679909991895e0137",
+    "p.gCOTI": "0xbdcc99978d502Fd0CE58A48E4C261ec65313cEd0",
+
+    // Bridges
+    PrivacyBridgeWETH: "0x151Ac2DE927552FF487ecf4a34b54936602db400",
+    PrivacyBridgeWBTC: "0x4148556faf95D77CBB8AEF999DcB047ce1d53d06",
+    PrivacyBridgeUSDT: "0xa2e88d96688555661AbB9f7f0f1f1643CEc524c5",
+    PrivacyBridgeUSDCe: "0x8633773dac4794d8fB00F5093141d2cCF1C45Ff1",
+    PrivacyBridgeWADA: "0xf33E6DE9827851821944fc1FE439de03857Bee52",
+    PrivacyBridgegCOTI: "0xB0cdd47aE73738B6297CF22d24DD94b8b28c2217"
+  },
+  
+  2632500: {
+    // Native
+    PrivateCoti: "0x143705349957A236d74e0aDb5673F880fEDB101f",
+    PrivacyBridgeCotiNative: "0x6056bFE6776df4bEa7235A19f6D672089b4cdBeB",
+
+    // Public Tokens
+    WETH: "0x639aCc80569c5FC83c6FBf2319A6Cc38bBfe26d1",
+    WBTC: "0x8C39B1fD0e6260fdf20652Fc436d25026832bfEA",
+    USDT: "0xfA6f73446b17A97a56e464256DA54AD43c2Cbc3E",
+    USDC_E: "0xf1Feebc4376c68B7003450ae66343Ae59AB37D3C",
+    WADA: "0xe757Ca19d2c237AA52eBb1d2E8E4368eeA3eb331",
+    gCOTI: "0x7637C7838EC4Ec6b85080F28A678F8E234bB83D1",
+
+    // Private Tokens
+    "p.WETH": "",
+    "p.WBTC": "",
+    "p.USDT": "",
+    "p.USDC_E": "",
+    "p.WADA": "",
+    "p.gCOTI": "",
+
+    // Bridges
+    PrivacyBridgeWETH: "",
+    PrivacyBridgeWBTC: "",
+    PrivacyBridgeUSDT: "",
+    PrivacyBridgeUSDCe: "",
+    PrivacyBridgeWADA: "",
+    PrivacyBridgegCOTI: ""
+  }
+};
+
+export const BRIDGE_ABI = [
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_privateCoti",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AmountZero",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DepositBelowMinimum",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DepositDisabled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DepositExceedsMaximum",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EthTransferFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ExceedsRescueableAmount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientAccumulatedFees",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientCotiFee",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientEthBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidFee",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidLimitConfiguration",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WithdrawBelowMinimum",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WithdrawExceedsMaximum",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WithdrawFeesMustBeOverridden",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "grossAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "netAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "feeType",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newFeeBasisPoints",
+        "type": "uint256"
+      }
+    ],
+    "name": "FeeUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "FeesWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "minDeposit",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxDeposit",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "minWithdraw",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxWithdraw",
+        "type": "uint256"
+      }
+    ],
+    "name": "LimitsUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "grossAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "netAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdraw",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "FEE_DIVISOR",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_FEE_UNITS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accumulatedCotiFees",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accumulatedFees",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "deposit",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "depositFeeBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBridgeBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isDepositEnabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxDepositAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxWithdrawAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minDepositAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minWithdrawAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nativeCotiFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "name": "onTokenReceived",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "addOperator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "removeOperator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "isOperator",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "privateCoti",
+    "outputs": [
+      {
+        "internalType": "contract PrivateCOTI",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "rescueNative",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_feeBasisPoints",
+        "type": "uint256"
+      }
+    ],
+    "name": "setDepositFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsDepositEnabled",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_minDeposit",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxDeposit",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_minWithdraw",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxWithdraw",
+        "type": "uint256"
+      }
+    ],
+    "name": "setLimits",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_fee",
+        "type": "uint256"
+      }
+    ],
+    "name": "setNativeCotiFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_feeBasisPoints",
+        "type": "uint256"
+      }
+    ],
+    "name": "setWithdrawFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawCotiFees",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawFeeBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawFees",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+] as const;
+export const BRIDGE_ERC20_ABI = [
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_privateToken",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AmountTooLarge",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AmountTooSmall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "AmountZero",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CannotRescueBridgeToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DepositBelowMinimum",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DepositDisabled",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "DepositExceedsMaximum",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "EthTransferFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientAccumulatedFees",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientBridgeLiquidity",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientCotiFee",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InsufficientEthBalance",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidFee",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidLimitConfiguration",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidPrivateTokenAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidScalingFactor",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidTokenAddress",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidTokenSender",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NativeFeeRequiredForTransferAndCallWithdraw",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "TokenTransferFailed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WithdrawBelowMinimum",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WithdrawExceedsMaximum",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "WithdrawFeesMustBeOverridden",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "grossAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "netAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "feeType",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newFeeBasisPoints",
+        "type": "uint256"
+      }
+    ],
+    "name": "FeeUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "FeesWithdrawn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "minDeposit",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxDeposit",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "minWithdraw",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "maxWithdraw",
+        "type": "uint256"
+      }
+    ],
+    "name": "LimitsUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "grossAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "netAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdraw",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "FEE_DIVISOR",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_FEE_UNITS",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accumulatedCotiFees",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accumulatedFees",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "deposit",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "depositFeeBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isDepositEnabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxDepositAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxWithdrawAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minDepositAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minWithdrawAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nativeCotiFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "addOperator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "removeOperator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "isOperator",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "privateToken",
+    "outputs": [
+      {
+        "internalType": "contract IPrivateERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "rescueERC20",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_feeBasisPoints",
+        "type": "uint256"
+      }
+    ],
+    "name": "setDepositFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "_enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setIsDepositEnabled",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_minDeposit",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxDeposit",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_minWithdraw",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_maxWithdraw",
+        "type": "uint256"
+      }
+    ],
+    "name": "setLimits",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_fee",
+        "type": "uint256"
+      }
+    ],
+    "name": "setNativeCotiFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_feeBasisPoints",
+        "type": "uint256"
+      }
+    ],
+    "name": "setWithdrawFee",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "token",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdraw",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawCotiFees",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "withdrawFeeBasisPoints",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawFees",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+] as const;
+
+export const TOKEN_ABI = [
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "approver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidApprover",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ERC20InvalidMetadata",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidReceiver",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidSender",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20InvalidSpender",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "ERC20SelfTransferNotAllowed",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PublicAmountsDisabled",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      }
+    ],
+    "name": "TransferAndCallRequiresContract",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newAddress",
+        "type": "address"
+      }
+    ],
+    "name": "AccountEncryptionAddressSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "ctUint128",
+            "name": "ciphertextHigh",
+            "type": "uint256"
+          },
+          {
+            "internalType": "ctUint128",
+            "name": "ciphertextLow",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct ctUint256",
+        "name": "ownerValue",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "ctUint128",
+            "name": "ciphertextHigh",
+            "type": "uint256"
+          },
+          {
+            "internalType": "ctUint128",
+            "name": "ciphertextLow",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct ctUint256",
+        "name": "spenderValue",
+        "type": "tuple"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "PublicAmountsEnabledSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "internalType": "ctUint128",
+            "name": "ciphertextHigh",
+            "type": "uint256"
+          },
+          {
+            "internalType": "ctUint128",
+            "name": "ciphertextLow",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct ctUint256",
+        "name": "senderValue",
+        "type": "tuple"
+      },
+      {
+        "components": [
+          {
+            "internalType": "ctUint128",
+            "name": "ciphertextHigh",
+            "type": "uint256"
+          },
+          {
+            "internalType": "ctUint128",
+            "name": "ciphertextLow",
+            "type": "uint256"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct ctUint256",
+        "name": "receiverValue",
+        "type": "tuple"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MINTER_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "accountEncryptionAddress",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "isSpender",
+        "type": "bool"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "internalType": "gtUint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextHigh",
+                "type": "uint256"
+              },
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextLow",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ctUint256",
+            "name": "ciphertext",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextHigh",
+                "type": "uint256"
+              },
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextLow",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ctUint256",
+            "name": "ownerCiphertext",
+            "type": "tuple"
+          },
+          {
+            "components": [
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextHigh",
+                "type": "uint256"
+              },
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextLow",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ctUint256",
+            "name": "spenderCiphertext",
+            "type": "tuple"
+          }
+        ],
+        "internalType": "struct IPrivateERC20.Allowance",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextHigh",
+                "type": "uint256"
+              },
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextLow",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ctUint256",
+            "name": "ciphertext",
+            "type": "tuple"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct itUint256",
+        "name": "value",
+        "type": "tuple"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "internalType": "gtUint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approveGT",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "ctUint128",
+            "name": "ciphertextHigh",
+            "type": "uint256"
+          },
+          {
+            "internalType": "ctUint128",
+            "name": "ciphertextLow",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct ctUint256",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "gtUint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "burn",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextHigh",
+                "type": "uint256"
+              },
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextLow",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ctUint256",
+            "name": "ciphertext",
+            "type": "tuple"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct itUint256",
+        "name": "amount",
+        "type": "tuple"
+      }
+    ],
+    "name": "burn",
+    "outputs": [
+      {
+        "internalType": "gtBool",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "gtUint256",
+        "name": "gtAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "burnGt",
+    "outputs": [
+      {
+        "internalType": "gtBool",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextHigh",
+                "type": "uint256"
+              },
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextLow",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ctUint256",
+            "name": "ciphertext",
+            "type": "tuple"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct itUint256",
+        "name": "amount",
+        "type": "tuple"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      {
+        "internalType": "gtBool",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "gtUint256",
+        "name": "gtAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "mintGt",
+    "outputs": [
+      {
+        "internalType": "gtBool",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "publicAmountsEnabled",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "isSpender",
+        "type": "bool"
+      }
+    ],
+    "name": "reencryptAllowance",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "offBoardAddress",
+        "type": "address"
+      }
+    ],
+    "name": "setAccountEncryptionAddress",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "enabled",
+        "type": "bool"
+      }
+    ],
+    "name": "setPublicAmountsEnabled",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextHigh",
+                "type": "uint256"
+              },
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextLow",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ctUint256",
+            "name": "ciphertext",
+            "type": "tuple"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct itUint256",
+        "name": "value",
+        "type": "tuple"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "gtBool",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextHigh",
+                "type": "uint256"
+              },
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextLow",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ctUint256",
+            "name": "ciphertext",
+            "type": "tuple"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct itUint256",
+        "name": "amount",
+        "type": "tuple"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "transferAndCall",
+    "outputs": [
+      {
+        "internalType": "gtBool",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "transferAndCall",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "components": [
+          {
+            "components": [
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextHigh",
+                "type": "uint256"
+              },
+              {
+                "internalType": "ctUint128",
+                "name": "ciphertextLow",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct ctUint256",
+            "name": "ciphertext",
+            "type": "tuple"
+          },
+          {
+            "internalType": "bytes",
+            "name": "signature",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct itUint256",
+        "name": "value",
+        "type": "tuple"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "internalType": "gtBool",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "gtUint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFromGT",
+    "outputs": [
+      {
+        "internalType": "gtBool",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "gtUint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferGT",
+    "outputs": [
+      {
+        "internalType": "gtBool",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+] as const;
+
+export const MINIMUM_PORTAL_IN_AMOUNTS: Record<string, string> = {
+  "WBTC": "0.0000145",
+  "WETH": "0.000497",
+  "WADA": "4",
+  "COTI": "82",
+  "gCOTI": "390",
+  "USDT": "1",
+  "USDC.e": "1"
+};
+
+export const ERC20_ABI = [
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_spender",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "name": "_spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  }
+] as const;
+
+export interface TokenConfig {
+  symbol: string;
+  name: string;
+  icon: string;
+  decimals: number;
+  isPrivate: boolean;
+  addressKey?: string; // Key in CONTRACT_ADDRESSES[chainId]
+  bridgeAddressKey?: string; // Key in CONTRACT_ADDRESSES[chainId]
+}
+
+export const SUPPORTED_TOKENS: TokenConfig[] = [
+  // Public Tokens
+  { symbol: "COTI", name: "COTI", icon: "/icons/coti.svg", decimals: 18, isPrivate: false, bridgeAddressKey: "PrivacyBridgeCotiNative" }, // Native COTI, no address key needed
+  { symbol: "WETH", name: "Wrapped Ether", icon: "/icons/wETH.svg", decimals: 18, isPrivate: false, addressKey: "WETH", bridgeAddressKey: "PrivacyBridgeWETH" },
+  { symbol: "WBTC", name: "Wrapped BTC", icon: "/icons/wBTC.svg", decimals: 8, isPrivate: false, addressKey: "WBTC", bridgeAddressKey: "PrivacyBridgeWBTC" },
+  { symbol: "USDT", name: "Tether USD", icon: "/icons/usdt.svg", decimals: 6, isPrivate: false, addressKey: "USDT", bridgeAddressKey: "PrivacyBridgeUSDT" },
+  { symbol: "USDC.e", name: "Bridged USDC", icon: "/icons/USDC.svg", decimals: 6, isPrivate: false, addressKey: "USDC_E", bridgeAddressKey: "PrivacyBridgeUSDCe" },
+  { symbol: "WADA", name: "Wrapped ADA", icon: "/icons/wADA.svg", decimals: 6, isPrivate: false, addressKey: "WADA", bridgeAddressKey: "PrivacyBridgeWADA" },
+  { symbol: "gCOTI", name: "gCOTI", icon: "/icons/gcoti.svg", decimals: 18, isPrivate: false, addressKey: "gCOTI", bridgeAddressKey: "PrivacyBridgegCOTI" },
+
+  // Private Tokens
+  { symbol: "p.COTI", name: "p.COTI", icon: "/icons/coti.svg", decimals: 18, isPrivate: true, addressKey: "PrivateCoti", bridgeAddressKey: "PrivacyBridgeCotiNative" },
+  { symbol: "p.WETH", name: "p.WETH", icon: "/icons/wETH.svg", decimals: 18, isPrivate: true, addressKey: "p.WETH", bridgeAddressKey: "PrivacyBridgeWETH" },
+  { symbol: "p.WBTC", name: "p.WBTC", icon: "/icons/wBTC.svg", decimals: 8, isPrivate: true, addressKey: "p.WBTC", bridgeAddressKey: "PrivacyBridgeWBTC" },
+  { symbol: "p.USDT", name: "p.USDT", icon: "/icons/usdt.svg", decimals: 6, isPrivate: true, addressKey: "p.USDT", bridgeAddressKey: "PrivacyBridgeUSDT" },
+  { symbol: "p.USDC.e", name: "p.USDC.e", icon: "/icons/USDC.svg", decimals: 6, isPrivate: true, addressKey: "p.USDC_E", bridgeAddressKey: "PrivacyBridgeUSDCe" },
+  { symbol: "p.WADA", name: "p.WADA", icon: "/icons/wADA.svg", decimals: 6, isPrivate: true, addressKey: "p.WADA", bridgeAddressKey: "PrivacyBridgeWADA" },
+  { symbol: "p.gCOTI", name: "p.gCOTI", icon: "/icons/gcoti.svg", decimals: 18, isPrivate: true, addressKey: "p.gCOTI", bridgeAddressKey: "PrivacyBridgegCOTI" },
+];

--- a/deploy/privacy_bridge/redeploy-private-and-bridges.cjs
+++ b/deploy/privacy_bridge/redeploy-private-and-bridges.cjs
@@ -1,0 +1,279 @@
+/**
+ * Redeployment script for Private Tokens and Bridges only.
+ *
+ * Fetches the current public token addresses from the remote config.ts in the
+ * coti-privacy-portal repo, saves a local copy to deploy/privacy_bridge/config.ts,
+ * and writes the updated addresses back to that local file after deployment.
+ *
+ * Run with:
+ *   npx hardhat compile
+ *   npx hardhat run deploy/privacy_bridge/redeploy-private-and-bridges.cjs --network coti-testnet
+ *   npx hardhat run deploy/privacy_bridge/redeploy-private-and-bridges.cjs --network coti-mainnet
+ */
+const hre  = require("hardhat");
+const fs   = require("node:fs");
+const path = require("node:path");
+
+const CHAIN_IDS = {
+    "coti-testnet": 7082400,
+    "coti-mainnet": 2632500,
+};
+
+// Local config.ts alongside this script
+const CONFIG_PATH = path.resolve(__dirname, "config.ts");
+
+/**
+ * Parse the given chainId block from a config.ts string and return a plain address map.
+ */
+function readAddressesForChain(chainId) {
+    const src = fs.readFileSync(CONFIG_PATH, "utf8");
+
+    const startMarker = `${chainId}: {`;
+    const startIdx = src.indexOf(startMarker);
+    if (startIdx === -1) throw new Error(`Could not find ${chainId} block in config.ts`);
+
+    let depth = 0, blockStart = src.indexOf("{", startIdx), i = blockStart;
+    while (i < src.length) {
+        if (src[i] === "{") depth++;
+        else if (src[i] === "}") { depth--; if (depth === 0) break; }
+        i++;
+    }
+    const block = src.slice(blockStart + 1, i);
+
+    const addresses = {};
+    const lines = block.split('\n');
+    for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('//')) continue;
+        
+        const colonIdx = trimmed.indexOf(':');
+        if (colonIdx === -1) continue;
+        
+        const keyRaw = trimmed.substring(0, colonIdx).trim();
+        let valRaw = trimmed.substring(colonIdx + 1).trim();
+        
+        if (valRaw.endsWith(',')) {
+            valRaw = valRaw.slice(0, -1).trim();
+        }
+        
+        let key = keyRaw;
+        if ((key.startsWith('"') && key.endsWith('"')) || (key.startsWith("'") && key.endsWith("'"))) {
+            key = key.substring(1, key.length - 1);
+        }
+        
+        let val = valRaw;
+        if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+            val = val.substring(1, val.length - 1);
+        }
+        
+        if (key && val) {
+            addresses[key] = val;
+        }
+    }
+    return addresses;
+}
+
+async function main() {
+    const [deployer] = await hre.ethers.getSigners();
+    const networkName = hre.network.name;
+    const chainId = CHAIN_IDS[networkName];
+
+    if (!chainId) {
+        throw new Error(`Unsupported network: "${networkName}". Use --network coti-testnet or --network coti-mainnet`);
+    }
+
+    console.log("Redeploying with account:", deployer.address);
+    console.log("Network:", networkName, `(chainId: ${chainId})`);
+
+    // ── Read current addresses from local config.ts ────────────────────────
+    console.log("\n--- Reading current addresses from config.ts ---");
+    const current = readAddressesForChain(chainId);
+
+    const publicTokens = {
+        WETH:   current["WETH"],
+        WBTC:   current["WBTC"],
+        USDT:   current["USDT"],
+        USDC_E: current["USDC_E"],
+        WADA:   current["WADA"],
+        gCOTI:  current["gCOTI"],
+    };
+
+    for (const [key, addr] of Object.entries(publicTokens)) {
+        if (!addr) throw new Error(`Missing public token address for ${key} in config.ts (${chainId} block)`);
+        console.log(`  ${key}: ${addr}`);
+    }
+
+    const newAddresses = { ...publicTokens };
+
+    // ── 1. Redeploy Private Tokens ─────────────────────────────────────────
+    console.log("\n--- Redeploying Private Tokens ---");
+    const privateTokens = [
+        { name: "PrivateCOTI",                        key: "PrivateCOTI" },
+        { name: "PrivateWrappedEther",                 key: "PrivateWrappedEther" },
+        { name: "PrivateWrappedBTC",                   key: "PrivateWrappedBTC" },
+        { name: "PrivateTetherUSD",                    key: "PrivateTetherUSD" },
+        { name: "PrivateBridgedUSDC",                  key: "PrivateBridgedUSDC" },
+        { name: "PrivateWrappedADA",                   key: "PrivateWrappedADA" },
+        { name: "PrivateCOTITreasuryGovernanceToken",  key: "PrivateCOTITreasuryGovernanceToken" },
+    ];
+
+    for (const pt of privateTokens) {
+        process.stdout.write(`  Deploying ${pt.name}... `);
+        const Factory = await hre.ethers.getContractFactory(pt.name);
+        const contract = await Factory.deploy({ gasLimit: 12000000 });
+        await contract.waitForDeployment();
+        newAddresses[pt.key] = await contract.getAddress();
+        console.log(`✅ ${newAddresses[pt.key]}`);
+    }
+
+    // ── 2. Redeploy Bridges ────────────────────────────────────────────────
+    console.log("\n--- Redeploying Bridges ---");
+    const bridges = [
+        { name: "PrivacyBridgeCotiNative", publicKey: null,       privateKey: "PrivateCOTI",                         bridgeKey: "PrivacyBridgeCotiNative" },
+        { name: "PrivacyBridgeWETH",       publicKey: "WETH",     privateKey: "PrivateWrappedEther",                 bridgeKey: "PrivacyBridgeWETH" },
+        { name: "PrivacyBridgeWBTC",       publicKey: "WBTC",     privateKey: "PrivateWrappedBTC",                   bridgeKey: "PrivacyBridgeWBTC" },
+        { name: "PrivacyBridgeUSDT",       publicKey: "USDT",     privateKey: "PrivateTetherUSD",                    bridgeKey: "PrivacyBridgeUSDT" },
+        { name: "PrivacyBridgeUSDCe",      publicKey: "USDC_E",   privateKey: "PrivateBridgedUSDC",                  bridgeKey: "PrivacyBridgeUSDCe" },
+        { name: "PrivacyBridgeWADA",       publicKey: "WADA",     privateKey: "PrivateWrappedADA",                   bridgeKey: "PrivacyBridgeWADA" },
+        { name: "PrivacyBridgegCoti",      publicKey: "gCOTI",    privateKey: "PrivateCOTITreasuryGovernanceToken",  bridgeKey: "PrivacyBridgegCoti" },
+    ];
+
+    for (const bridge of bridges) {
+        process.stdout.write(`  Deploying ${bridge.name}... `);
+        const Factory = await hre.ethers.getContractFactory(bridge.name);
+        let contract;
+        if (bridge.publicKey) {
+            contract = await Factory.deploy(
+                newAddresses[bridge.publicKey],
+                newAddresses[bridge.privateKey],
+                { gasLimit: 12000000 }
+            );
+        } else {
+            contract = await Factory.deploy(newAddresses[bridge.privateKey], { gasLimit: 12000000 });
+        }
+        await contract.waitForDeployment();
+        newAddresses[bridge.bridgeKey] = await contract.getAddress();
+        console.log(`✅ ${newAddresses[bridge.bridgeKey]}`);
+    }
+
+    // ── 3. Grant Roles ─────────────────────────────────────────────────────
+    console.log("\n--- Granting Roles ---");
+    const MINTER_ROLE = hre.ethers.id("MINTER_ROLE");
+    const BURNER_ROLE  = hre.ethers.id("BURNER_ROLE");
+
+    for (const bridge of bridges) {
+        const ptAddress     = newAddresses[bridge.privateKey];
+        const bridgeAddress = newAddresses[bridge.bridgeKey];
+        const ptContract    = await hre.ethers.getContractAt("PrivateERC20", ptAddress);
+
+        process.stdout.write(`  ${bridge.name}: granting MINTER_ROLE... `);
+        const tx1 = await ptContract.grantRole(MINTER_ROLE, bridgeAddress, { gasLimit: 5000000 });
+        await tx1.wait();
+        process.stdout.write("✅  BURNER_ROLE... ");
+        const tx2 = await ptContract.grantRole(BURNER_ROLE, bridgeAddress, { gasLimit: 5000000 });
+        await tx2.wait();
+        console.log("✅");
+    }
+
+    // ── 4. Update local deploy/privacy_bridge/config.ts ─────────────────
+    console.log("\n--- Updating local config.ts ---");
+
+    let configContent = fs.readFileSync(CONFIG_PATH, "utf8");
+
+    const newBlock = `    // ${chainId === 2632500 ? "COTI Mainnet" : "COTI Testnet"}
+    ${chainId}: {
+    // Native
+    PrivateCoti: "${newAddresses.PrivateCOTI}",
+    PrivacyBridgeCotiNative: "${newAddresses.PrivacyBridgeCotiNative}",
+
+    // Public Tokens
+    WETH: "${newAddresses.WETH}",
+    WBTC: "${newAddresses.WBTC}",
+    USDT: "${newAddresses.USDT}",
+    USDC_E: "${newAddresses.USDC_E}",
+    WADA: "${newAddresses.WADA}",
+    gCOTI: "${newAddresses.gCOTI}",
+
+    // Private Tokens
+    "p.WETH": "${newAddresses.PrivateWrappedEther}",
+    "p.WBTC": "${newAddresses.PrivateWrappedBTC}",
+    "p.USDT": "${newAddresses.PrivateTetherUSD}",
+    "p.USDC_E": "${newAddresses.PrivateBridgedUSDC}",
+    "p.WADA": "${newAddresses.PrivateWrappedADA}",
+    "p.gCOTI": "${newAddresses.PrivateCOTITreasuryGovernanceToken}",
+
+    // Bridges
+    PrivacyBridgeWETH: "${newAddresses.PrivacyBridgeWETH}",
+    PrivacyBridgeWBTC: "${newAddresses.PrivacyBridgeWBTC}",
+    PrivacyBridgeUSDT: "${newAddresses.PrivacyBridgeUSDT}",
+    PrivacyBridgeUSDCe: "${newAddresses.PrivacyBridgeUSDCe}",
+    PrivacyBridgeWADA: "${newAddresses.PrivacyBridgeWADA}",
+    PrivacyBridgegCOTI: "${newAddresses.PrivacyBridgegCoti}"
+  }`;
+
+    // Use the parser to find the exact start/end of the chainId block, then replace it.
+    const startMarker = `${chainId}: {`;
+    const startIdx = configContent.indexOf(startMarker);
+    if (startIdx === -1) {
+        console.error(`❌ Could not find ${chainId} block in config.ts. Please update manually.`);
+        process.exit(1);
+    }
+
+    // Walk backwards to include any preceding comment lines (e.g. "// COTI Testnet")
+    let blockStart = startIdx;
+    let lineStart = configContent.lastIndexOf("\n", startIdx - 1);
+    // Check up to 2 lines back for a comment (handles blank line between comment and chainId)
+    for (let look = 0; look < 2 && lineStart > 0; look++) {
+        const prevLineStart = configContent.lastIndexOf("\n", lineStart - 1);
+        const prevLine = configContent.slice(prevLineStart + 1, lineStart).trim();
+        if (prevLine.startsWith("//")) {
+            blockStart = prevLineStart + 1;
+            break;
+        }
+        if (prevLine === "") {
+            // blank line — keep looking
+            lineStart = prevLineStart;
+            continue;
+        }
+        break;
+    }
+
+    // Walk forward to find the matching closing brace
+    let depth = 0;
+    let i = configContent.indexOf("{", startIdx);
+    while (i < configContent.length) {
+        if (configContent[i] === "{") depth++;
+        else if (configContent[i] === "}") {
+            depth--;
+            if (depth === 0) break;
+        }
+        i++;
+    }
+    const blockEnd = i + 1; // include the closing "}"
+
+    configContent = configContent.slice(0, blockStart) + newBlock + configContent.slice(blockEnd);
+    fs.writeFileSync(CONFIG_PATH, configContent, "utf8");
+    console.log(`✅ config.ts updated at ${CONFIG_PATH}`);
+
+    // ── 5. Summary ────────────────────────────────────────────────────────
+    console.log("\n========================================================");
+    console.log("  DEPLOYMENT COMPLETE");
+    console.log("========================================================");
+    console.log(`  PrivateCoti:             ${newAddresses.PrivateCOTI}`);
+    console.log(`  PrivacyBridgeCotiNative: ${newAddresses.PrivacyBridgeCotiNative}`);
+    console.log(`  p.WETH:                  ${newAddresses.PrivateWrappedEther}`);
+    console.log(`  p.WBTC:                  ${newAddresses.PrivateWrappedBTC}`);
+    console.log(`  p.USDT:                  ${newAddresses.PrivateTetherUSD}`);
+    console.log(`  p.USDC_E:                ${newAddresses.PrivateBridgedUSDC}`);
+    console.log(`  p.WADA:                  ${newAddresses.PrivateWrappedADA}`);
+    console.log(`  p.gCOTI:                 ${newAddresses.PrivateCOTITreasuryGovernanceToken}`);
+    console.log(`  PrivacyBridgeWETH:       ${newAddresses.PrivacyBridgeWETH}`);
+    console.log(`  PrivacyBridgeWBTC:       ${newAddresses.PrivacyBridgeWBTC}`);
+    console.log(`  PrivacyBridgeUSDT:       ${newAddresses.PrivacyBridgeUSDT}`);
+    console.log(`  PrivacyBridgeUSDCe:      ${newAddresses.PrivacyBridgeUSDCe}`);
+    console.log(`  PrivacyBridgeWADA:       ${newAddresses.PrivacyBridgeWADA}`);
+    console.log(`  PrivacyBridgegCOTI:      ${newAddresses.PrivacyBridgegCoti}`);
+    console.log("========================================================\n");
+}
+
+main().catch((e) => { console.error(e); process.exitCode = 1; });


### PR DESCRIPTION
This PR adds the deployment scripts to reliably deploy the private tokens and privacy bridges. It only contains the contents inside the `deploy/` folder. Run with `npx hardhat deploy ...` as documented.