### PR TITLE
feat: Dynamic fees for Privacy Bridge contracts

### DIFF
--- a/contracts/oracle/CotiPriceConsumer.sol
+++ b/contracts/oracle/CotiPriceConsumer.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./IStdReference.sol";
+
+/**
+ * @title CotiPriceConsumer
+ * @notice Retrieves token/USD prices from the Band Protocol oracle.
+ * @dev All prices returned by Band Protocol are scaled by 1e18.
+ *      For example, a rate of 50000000000000000 means $0.05.
+ */
+contract CotiPriceConsumer {
+    /// @notice Band Protocol StdReferenceProxy on COTI .
+    IStdReference public immutable ref;
+
+    /// @notice Maximum acceptable age (in seconds) for oracle data before it is considered stale.
+    uint256 public maxStaleness;
+
+    /// @notice Emitted when the staleness threshold is updated.
+    event MaxStalenessUpdated(uint256 oldValue, uint256 newValue);
+
+    /// @notice Thrown when the oracle data is older than the allowed staleness window.
+    error StaleOracleData(uint256 lastUpdated, uint256 threshold);
+
+    address public owner;
+
+    /// @notice Minimum allowed staleness threshold (1 hour).
+    uint256 public constant MIN_STALENESS = 1 hours;
+
+    /// @notice Thrown when the staleness value is below the minimum.
+    error StalenessTooLow(uint256 provided, uint256 minimum);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "CotiPriceConsumer: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @param _ref          Address of the Band Protocol StdReferenceProxy contract.
+     * @param _maxStaleness Maximum acceptable data age in seconds (0 = no staleness check).
+     */
+    constructor(address _ref, uint256 _maxStaleness) {
+        require(_ref != address(0), "CotiPriceConsumer: zero ref address");
+        if (_maxStaleness < MIN_STALENESS) revert StalenessTooLow(_maxStaleness, MIN_STALENESS);
+        ref = IStdReference(_ref);
+        maxStaleness = _maxStaleness;
+        owner = msg.sender;
+    }
+
+    /// @notice Returns the rate, last update timestamp, staleness threshold, and current block timestamp for any base/USD pair.
+    /// @return rate           The price scaled by 1e18
+    /// @return lastUpdated    Block timestamp when the oracle data was last updated
+    /// @return threshold      The staleness cutoff (block.timestamp - maxStaleness), or 0 if disabled
+    /// @return blockTimestamp The current block.timestamp
+    function getPriceWithMeta(string calldata _base) external view returns (uint256 rate, uint256 lastUpdated, uint256 threshold, uint256 blockTimestamp) {
+        IStdReference.ReferenceData memory data = _getPrice(_base);
+        rate = data.rate;
+        lastUpdated = data.lastUpdatedBase;
+        threshold = block.timestamp - maxStaleness;
+        blockTimestamp = block.timestamp;
+    }
+
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Internal helper
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * @dev Queries the Band oracle for `_base`/USD and optionally enforces staleness.
+     */
+    function _getPrice(string memory _base) internal view returns (IStdReference.ReferenceData memory data) {
+        data = ref.getReferenceData(_base, "USD");
+
+        uint256 threshold = block.timestamp - maxStaleness;
+        if (data.lastUpdatedBase < threshold) {
+            revert StaleOracleData(data.lastUpdatedBase, threshold);
+        }
+    }
+
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Generic getter — query any symbol the oracle supports
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// @notice Returns the COTI/USD rate scaled by 1e18.
+    function getCotiPrice() external view returns (uint256) {
+        return _getPrice("COTI").rate;
+    }
+
+    /// @notice Returns the rate for an arbitrary base/USD pair scaled by 1e18.
+    function getPrice(string calldata _base) external view returns (uint256) {
+        return _getPrice(_base).rate;
+    }
+
+
+    /// @notice Returns the full ReferenceData for an arbitrary base/USD pair.
+    function getPriceData(string calldata _base) external view returns (IStdReference.ReferenceData memory) {
+        return _getPrice(_base);
+    }
+
+    /**
+     * @notice Updates the maximum staleness threshold.
+     * @param _maxStaleness New threshold in seconds (0 = disable check).
+     */
+    function setMaxStaleness(uint256 _maxStaleness) external onlyOwner {
+        if (_maxStaleness < MIN_STALENESS) revert StalenessTooLow(_maxStaleness, MIN_STALENESS);
+        emit MaxStalenessUpdated(maxStaleness, _maxStaleness);
+        maxStaleness = _maxStaleness;
+    }
+}

--- a/contracts/oracle/ICotiPriceConsumer.sol
+++ b/contracts/oracle/ICotiPriceConsumer.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+/**
+ * @title ICotiPriceConsumer
+ * @notice Minimal interface for the CotiPriceConsumer oracle used by the bridge
+ */
+interface ICotiPriceConsumer {
+    /// @notice Returns the COTI/USD rate scaled by 1e18.
+    function getCotiPrice() external view returns (uint256);
+
+    /// @notice Returns the rate for an arbitrary base/USD pair scaled by 1e18.
+    function getPrice(string calldata _base) external view returns (uint256);
+
+    /// @notice Returns rate + staleness metadata for any base/USD pair.
+    function getPriceWithMeta(string calldata _base) external view returns (uint256 rate, uint256 lastUpdated, uint256 threshold, uint256 blockTimestamp);
+}

--- a/contracts/oracle/IStdReference.sol
+++ b/contracts/oracle/IStdReference.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title IStdReference
+ * @notice Band Protocol Standard Reference interface for querying price data.
+ */
+interface IStdReference {
+    struct ReferenceData {
+        uint256 rate;            // base/quote exchange rate, scaled by 1e18
+        uint256 lastUpdatedBase; // UNIX epoch when the base price was last updated
+        uint256 lastUpdatedQuote; // UNIX epoch when the quote price was last updated
+    }
+
+    /// @notice Returns the price data for a single base/quote pair.
+    function getReferenceData(
+        string memory _base,
+        string memory _quote
+    ) external view returns (ReferenceData memory);
+
+    /// @notice Returns the price data for multiple base/quote pairs.
+    function getReferenceDataBulk(
+        string[] memory _bases,
+        string[] memory _quotes
+    ) external view returns (ReferenceData[] memory);
+}

--- a/contracts/privacyBridge/PrivacyBridge.sol
+++ b/contracts/privacyBridge/PrivacyBridge.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/security/Pausable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
+import "../oracle/ICotiPriceConsumer.sol";
 
 /**
  * @title PrivacyBridge
@@ -22,6 +23,8 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     event OperatorRemoved(address indexed account, address indexed by);
     event DepositEnabledUpdated(bool enabled, address indexed by);
     event NativeCotiFeeUpdated(uint256 fee, address indexed by);
+    event DynamicFeeUpdated(string feeType, uint256 fixedFee, uint256 percentageBps, uint256 maxFee);
+    event PriceOracleUpdated(address indexed oldOracle, address indexed newOracle);
 
     /// @notice Maximum amount that can be deposited in a single transaction
     uint256 public maxDepositAmount;
@@ -59,6 +62,34 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     /// @notice Fee in native COTI for bridge operations
     uint256 public nativeCotiFee;
 
+
+    // Privacy Bridge defines default Fees
+    // those fees can be overwritten using
+    // setDepositDynamicFee available for OPERATORS and ADMIN
+
+    /// @notice Deposit fee floor in COTI wei
+    uint256 public depositFixedFee = 10 ether;
+
+    /// @notice Deposit percentage (500/1,000,000 = 0.05%)
+    uint256 public depositPercentageBps = 500;
+
+    /// @notice Deposit fee cap in COTI wei
+    uint256 public depositMaxFee = 3000 ether;
+
+    /// @notice Withdraw fee floor in COTI wei
+    uint256 public withdrawFixedFee = 3 ether;
+
+    /// @notice Withdraw percentage (250/1,000,000 = 0.025%)
+    uint256 public withdrawPercentageBps = 250;
+
+    /// @notice Withdraw fee cap in COTI wei
+    uint256 public withdrawMaxFee = 1500 ether;
+
+    // --- END OF DEFAULT FEES
+
+    /// @notice CotiPriceConsumer contract address
+    address public priceOracle;
+
     error AmountZero();
     error InsufficientEthBalance();
     error EthTransferFailed();
@@ -66,6 +97,7 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     error DepositDisabled();
     error InsufficientCotiFee();
     error BridgePaused();
+    error OracleTimestampMismatch(uint256 expected, uint256 actual);
 
     // Limits errors
     error InvalidLimitConfiguration();
@@ -74,6 +106,7 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     error WithdrawBelowMinimum();
     error WithdrawExceedsMaximum();
     error InvalidFee();
+    error InvalidFeeConfiguration();
     error InsufficientAccumulatedFees();
     error WithdrawFeesMustBeOverridden();
 
@@ -263,6 +296,109 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
         emit NativeCotiFeeUpdated(_fee, msg.sender);
     }
 
+    /**
+     * @notice Validate that the oracle's lastUpdated timestamp matches the caller's expectation.
+     * @dev Reverts with {OracleTimestampMismatch} if the oracle data has been refreshed since
+     *      the user called estimateDepositFee / estimateWithdrawFee.
+     * @param expectedTimestamp The lastUpdated value the caller received from the estimate call.
+     */
+    function _validateOracleTimestamp(uint256 expectedTimestamp) internal view {
+        (, uint256 lastUpdated,,) = ICotiPriceConsumer(priceOracle).getPriceWithMeta("COTI");
+        if (lastUpdated != expectedTimestamp) revert OracleTimestampMismatch(expectedTimestamp, lastUpdated);
+    }
+
+    /**
+     * @notice Calculate the dynamic fee using the floor/cap formula
+     * @param percentageFeeCoti The percentage-based fee component in COTI
+     * @param fixedFee The minimum fee floor in COTI
+     * @param maxFee The maximum fee cap in COTI
+     * @return The computed fee: min(max(fixedFee, percentageFeeCoti), maxFee)
+     */
+    function _calculateDynamicFee(
+        uint256 percentageFeeCoti,
+        uint256 fixedFee,
+        uint256 maxFee
+    ) internal pure returns (uint256) {
+        uint256 fee = percentageFeeCoti > fixedFee ? percentageFeeCoti : fixedFee;
+        return fee > maxFee ? maxFee : fee;
+    }
+
+    /**
+     * @notice Estimate the deposit fee for a given amount
+     * @param amount The amount to estimate the deposit fee for
+     * @return fee           The estimated fee in native COTI (18 decimals)
+     * @return lastUpdated   Oracle data last update timestamp
+     * @return threshold     Staleness cutoff timestamp (0 if disabled)
+     * @return blockTimestamp Current block.timestamp
+     * @dev Must be overridden by derived contracts (Native and ERC20 bridges).
+     */
+    function estimateDepositFee(uint256 amount) external view virtual returns (uint256 fee, uint256 lastUpdated, uint256 threshold, uint256 blockTimestamp);
+
+    /**
+     * @notice Estimate the withdrawal fee for a given amount
+     * @param amount The amount to estimate the withdrawal fee for
+     * @return fee           The estimated fee in native COTI (18 decimals)
+     * @return lastUpdated   Oracle data last update timestamp
+     * @return threshold     Staleness cutoff timestamp (0 if disabled)
+     * @return blockTimestamp Current block.timestamp
+     * @dev Must be overridden by derived contracts (Native and ERC20 bridges).
+     */
+    function estimateWithdrawFee(uint256 amount) external view virtual returns (uint256 fee, uint256 lastUpdated, uint256 threshold, uint256 blockTimestamp);
+
+    /**
+     * @notice Set the deposit dynamic fee parameters
+     * @param _fixedFee New deposit fee floor in COTI wei
+     * @param _percentageBps New deposit percentage (max MAX_FEE_UNITS = 10%)
+     * @param _maxFee New deposit fee cap in COTI wei
+     * @dev Only the operator can call this function
+     */
+    function setDepositDynamicFee(
+        uint256 _fixedFee,
+        uint256 _percentageBps,
+        uint256 _maxFee
+    ) external onlyOperator {
+        if (_maxFee == 0) revert InvalidFeeConfiguration();
+        if (_fixedFee > _maxFee) revert InvalidFeeConfiguration();
+        if (_percentageBps > MAX_FEE_UNITS) revert InvalidFee();
+        depositFixedFee = _fixedFee;
+        depositPercentageBps = _percentageBps;
+        depositMaxFee = _maxFee;
+        emit DynamicFeeUpdated("deposit", _fixedFee, _percentageBps, _maxFee);
+    }
+
+    /**
+     * @notice Set the withdraw dynamic fee parameters
+     * @param _fixedFee New withdraw fee floor in COTI wei
+     * @param _percentageBps New withdraw percentage (max MAX_FEE_UNITS = 10%)
+     * @param _maxFee New withdraw fee cap in COTI wei
+     * @dev Only the operator can call this function
+     */
+    function setWithdrawDynamicFee(
+        uint256 _fixedFee,
+        uint256 _percentageBps,
+        uint256 _maxFee
+    ) external onlyOperator {
+        if (_maxFee == 0) revert InvalidFeeConfiguration();
+        if (_fixedFee > _maxFee) revert InvalidFeeConfiguration();
+        if (_percentageBps > MAX_FEE_UNITS) revert InvalidFee();
+        withdrawFixedFee = _fixedFee;
+        withdrawPercentageBps = _percentageBps;
+        withdrawMaxFee = _maxFee;
+        emit DynamicFeeUpdated("withdraw", _fixedFee, _percentageBps, _maxFee);
+    }
+
+    /**
+     * @notice Set the price oracle address
+     * @param _oracle Address of the CotiPriceConsumer contract
+     * @dev Only the owner can call this function
+     */
+    function setPriceOracle(address _oracle) external onlyOwner {
+        if (_oracle == address(0)) revert InvalidAddress();
+        address oldOracle = priceOracle;
+        priceOracle = _oracle;
+        emit PriceOracleUpdated(oldOracle, _oracle);
+    }
+
 
     /**
      * @notice Calculate fee amount based on the input amount and fee basis points
@@ -305,7 +441,7 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     function withdrawFees(
         address to,
         uint256 amount
-    ) external virtual onlyOperator {
+    ) external virtual onlyOwner {
         if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
         if (amount > accumulatedFees) revert InsufficientAccumulatedFees();
@@ -321,7 +457,7 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
      * @dev Only the operator can call this function. Derived ERC20 bridges use this inherited implementation to withdraw
      *      accumulated native COTI fees; native bridge does not use this (accumulatedCotiFees remains 0).
      */
-    function withdrawCotiFees(address to, uint256 amount) external onlyOperator nonReentrant {
+    function withdrawCotiFees(address to, uint256 amount) external onlyOwner nonReentrant {
         if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
         if (amount > accumulatedCotiFees) revert InsufficientAccumulatedFees();

--- a/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
+++ b/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
@@ -29,30 +29,83 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
     }
 
     /**
+     * @notice Compute the dynamic fee in native COTI
+     * @param cotiAmount The COTI amount to compute fee for
+     * @param fixedFee The minimum fee floor in COTI wei
+     * @param percentageBps The percentage in basis points (relative to FEE_DIVISOR)
+     * @param maxFee The maximum fee cap in COTI wei
+     * @return The computed fee in COTI wei
+     */
+    function _computeCotiFee(
+        uint256 cotiAmount,
+        uint256 fixedFee,
+        uint256 percentageBps,
+        uint256 maxFee
+    ) internal view returns (uint256) {
+        uint256 cotiUsdRate = ICotiPriceConsumer(priceOracle).getCotiPrice();
+        uint256 txValueUsd = (cotiAmount * cotiUsdRate) / 1e18;
+        uint256 percentageFeeUsd = (txValueUsd * percentageBps) / FEE_DIVISOR;
+        uint256 percentageFeeCoti = (percentageFeeUsd * 1e18) / cotiUsdRate;
+        return _calculateDynamicFee(percentageFeeCoti, fixedFee, maxFee);
+    }
+
+    /**
+     * @notice Estimate the deposit fee in COTI for a given COTI amount
+     * @param cotiAmount The amount of native COTI to deposit
+     * @return fee           The estimated fee in COTI wei
+     * @return lastUpdated   Oracle data last update timestamp
+     * @return threshold     Staleness cutoff timestamp (0 if disabled)
+     * @return blockTimestamp Current block.timestamp
+     */
+    function estimateDepositFee(uint256 cotiAmount) external view override returns (uint256 fee, uint256 lastUpdated, uint256 threshold, uint256 blockTimestamp) {
+        fee = _computeCotiFee(cotiAmount, depositFixedFee, depositPercentageBps, depositMaxFee);
+        (,lastUpdated, threshold, blockTimestamp) = ICotiPriceConsumer(priceOracle).getPriceWithMeta("COTI");
+    }
+
+    /**
+     * @notice Estimate the withdrawal fee in COTI for a given COTI amount
+     * @param cotiAmount The amount of native COTI to withdraw
+     * @return fee           The estimated fee in COTI wei
+     * @return lastUpdated   Oracle data last update timestamp
+     * @return threshold     Staleness cutoff timestamp (0 if disabled)
+     * @return blockTimestamp Current block.timestamp
+     */
+    function estimateWithdrawFee(uint256 cotiAmount) external view override returns (uint256 fee, uint256 lastUpdated, uint256 threshold, uint256 blockTimestamp) {
+        fee = _computeCotiFee(cotiAmount, withdrawFixedFee, withdrawPercentageBps, withdrawMaxFee);
+        (,lastUpdated, threshold, blockTimestamp) = ICotiPriceConsumer(priceOracle).getPriceWithMeta("COTI");
+    }
+
+    /**
      * @notice Internal function to handle deposits
      * @param sender Address of the depositor
      */
-    function _deposit(address sender) internal {
+    function _deposit(address sender, uint256 oracleTimestamp) internal {
         if (!isDepositEnabled) revert DepositDisabled();
         if (msg.value == 0) revert AmountZero();
 
         _checkDepositLimits(msg.value);
+        _validateOracleTimestamp(oracleTimestamp);
 
-        // Deduct bridged-asset deposit fee, get net amount to mint
-        uint256 amountAfterFee = _collectTokenFee(msg.value, depositFeeBasisPoints);
+        // Compute dynamic fee in COTI
+        uint256 fee = _computeCotiFee(msg.value, depositFixedFee, depositPercentageBps, depositMaxFee);
+        uint256 netAmount = msg.value - fee;
+        if (netAmount == 0) revert AmountZero();
 
-        privateCoti.mint(sender, amountAfterFee);
+        accumulatedCotiFees += fee;
+
+        privateCoti.mint(sender, netAmount);
 
         // Emit gross deposit amount and net private tokens minted
-        emit Deposit(sender, msg.value, amountAfterFee);
+        emit Deposit(sender, msg.value, netAmount);
     }
 
     /**
      * @notice Deposit native COTI to receive private COTI (COTI.p)
+     * @param oracleTimestamp The oracle lastUpdated timestamp from estimateDepositFee (ensures fee hasn't changed)
      * @dev User sends native COTI with the transaction
      */
-    function deposit() external payable nonReentrant whenNotPaused {
-        _deposit(msg.sender);
+    function deposit(uint256 oracleTimestamp) external payable nonReentrant whenNotPaused {
+        _deposit(msg.sender, oracleTimestamp);
     }
 
     /**
@@ -62,22 +115,31 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
      */
     /**
      * @notice Handle callback from PrivateCoti.transferAndCall
-     * @dev Called when user transfers tokens to the bridge to withdraw. Third parameter (data) is required by ITokenReceiver but unused.
+     * @dev Called when user transfers tokens to the bridge to withdraw.
+     *      The `data` parameter must be abi-encoded uint256 oracleTimestamp.
      * @param from Address of the sender
      * @param amount Amount of tokens received
+     * @param data ABI-encoded uint256 oracleTimestamp from estimateWithdrawFee
      */
     function onTokenReceived(
         address from,
         uint256 amount,
-        bytes calldata
+        bytes calldata data
     ) external nonReentrant whenNotPaused returns (bool) {
         if (msg.sender != address(privateCoti)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
 
+        uint256 oracleTimestamp = abi.decode(data, (uint256));
+        _validateOracleTimestamp(oracleTimestamp);
+
         _checkWithdrawLimits(amount);
 
-        // Deduct bridged-asset withdrawal fee, get net amount to release
-        uint256 publicAmount = _collectTokenFee(amount, withdrawFeeBasisPoints);
+        // Compute dynamic withdrawal fee in COTI
+        uint256 fee = _computeCotiFee(amount, withdrawFixedFee, withdrawPercentageBps, withdrawMaxFee);
+        uint256 publicAmount = amount - fee;
+        if (publicAmount == 0) revert AmountZero();
+
+        accumulatedCotiFees += fee;
 
         if (address(this).balance < publicAmount)
             revert InsufficientEthBalance();
@@ -97,21 +159,28 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
     /**
      * @notice Withdraw native COTI by burning private COTI
      * @param amount Amount of private COTI to burn
+     * @param oracleTimestamp The oracle lastUpdated timestamp from estimateWithdrawFee (ensures fee hasn't changed)
      * @dev User must have approved the bridge to spend their private tokens.
      */
-    function withdraw(uint256 amount) external nonReentrant whenNotPaused {
-        _withdraw(msg.sender, amount);
+    function withdraw(uint256 amount, uint256 oracleTimestamp) external nonReentrant whenNotPaused {
+        _withdraw(msg.sender, amount, oracleTimestamp);
     }
 
     function _withdraw(
         address to,
-        uint256 amount
+        uint256 amount,
+        uint256 oracleTimestamp
     ) internal {
         if (amount == 0) revert AmountZero();
         _checkWithdrawLimits(amount);
+        _validateOracleTimestamp(oracleTimestamp);
 
-        // Deduct bridged-asset withdrawal fee, get net amount to release
-        uint256 publicAmount = _collectTokenFee(amount, withdrawFeeBasisPoints);
+        // Compute dynamic withdrawal fee in COTI
+        uint256 fee = _computeCotiFee(amount, withdrawFixedFee, withdrawPercentageBps, withdrawMaxFee);
+        uint256 publicAmount = amount - fee;
+        if (publicAmount == 0) revert AmountZero();
+
+        accumulatedCotiFees += fee;
 
         if (address(this).balance < publicAmount)
             revert InsufficientEthBalance();
@@ -131,11 +200,10 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
     }
 
     /**
-     * @notice Fallback function to handle direct COTI transfers as deposits
+     * @notice Fallback to accept native COTI sent directly (e.g. for liquidity top-up).
+     * @dev Does NOT trigger a deposit. Use deposit(oracleTimestamp) instead.
      */
-    receive() external payable nonReentrant whenNotPaused {
-        _deposit(msg.sender);
-    }
+    receive() external payable {}
 
     /**
      * @notice Get the native COTI balance held by the bridge
@@ -154,13 +222,13 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
     function withdrawFees(
         address to,
         uint256 amount
-    ) external override onlyOperator nonReentrant {
+    ) external override onlyOwner nonReentrant {
         if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
-        if (amount > accumulatedFees) revert InsufficientAccumulatedFees();
+        if (amount > accumulatedCotiFees) revert InsufficientAccumulatedFees();
         if (amount > address(this).balance) revert InsufficientEthBalance();
 
-        accumulatedFees -= amount;
+        accumulatedCotiFees -= amount;
 
         // Transfer native COTI tokens
         (bool success, ) = to.call{value: amount}("");

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -25,6 +25,9 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
     /// @notice Private token contract being minted/burned
     IPrivateERC20 public privateToken;
 
+    /// @notice Band oracle symbol for the bridged token (e.g., "ETH", "WBTC", "ADA", "USDC", "USDT")
+    string public tokenSymbol;
+
     error InvalidTokenAddress();
     error InvalidPrivateTokenAddress();
     error CannotRescueBridgeToken();
@@ -40,20 +43,70 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
     event ERC20Rescued(address indexed token, address indexed to, uint256 amount);
 
     /**
-     * @notice Collects the flat native COTI per-operation fee from msg.value and refunds any excess to the sender.
-     * @dev Reverts with {InsufficientCotiFee} if msg.value < nativeCotiFee.
-     *      Excess above nativeCotiFee is refunded best-effort; if the refund fails (e.g. sender is a
-     *      contract that cannot receive native tokens), the excess is added to accumulatedCotiFees so
-     *      it remains recoverable via {withdrawCotiFees} rather than being permanently stranded.
+     * @notice Compute the dynamic fee in COTI for an ERC20 bridge operation
+     * @param tokenAmount The amount of ERC20 tokens being bridged
+     * @param fixedFee The minimum fee floor in COTI
+     * @param percentageBps The percentage in basis points (relative to FEE_DIVISOR)
+     * @param maxFee The maximum fee cap in COTI
+     * @return The computed fee in native COTI (18 decimals)
      */
-    function _collectNativeFee() internal {
-        if (msg.value < nativeCotiFee) revert InsufficientCotiFee();
-        accumulatedCotiFees += nativeCotiFee;
-        if (msg.value > nativeCotiFee) {
-            uint256 excess = msg.value - nativeCotiFee;
+    function _computeErc20Fee(
+        uint256 tokenAmount,
+        uint256 fixedFee,
+        uint256 percentageBps,
+        uint256 maxFee
+    ) internal view returns (uint256) {
+        ICotiPriceConsumer oracle = ICotiPriceConsumer(priceOracle);
+        uint256 tokenUsdRate = oracle.getPrice(tokenSymbol);
+        uint256 cotiUsdRate = oracle.getCotiPrice();
+        uint8 tokenDecimals = IHasDecimals(address(token)).decimals();
+        uint256 txValueUsd = (tokenAmount * tokenUsdRate) / (10 ** tokenDecimals);
+        uint256 percentageFeeUsd = (txValueUsd * percentageBps) / FEE_DIVISOR;
+        uint256 percentageFeeCoti = (percentageFeeUsd * 1e18) / cotiUsdRate;
+        return _calculateDynamicFee(percentageFeeCoti, fixedFee, maxFee);
+    }
+
+    /**
+     * @notice Estimate the deposit fee in COTI for a given token amount
+     * @param tokenAmount The amount of ERC20 tokens to deposit
+     * @return fee           The estimated fee in native COTI (18 decimals)
+     * @return lastUpdated   Oracle data last update timestamp
+     * @return threshold     Staleness cutoff timestamp (0 if disabled)
+     * @return blockTimestamp Current block.timestamp
+     */
+    function estimateDepositFee(uint256 tokenAmount) external view override returns (uint256 fee, uint256 lastUpdated, uint256 threshold, uint256 blockTimestamp) {
+        fee = _computeErc20Fee(tokenAmount, depositFixedFee, depositPercentageBps, depositMaxFee);
+        (,lastUpdated, threshold, blockTimestamp) = ICotiPriceConsumer(priceOracle).getPriceWithMeta("COTI");
+    }
+
+    /**
+     * @notice Estimate the withdrawal fee in COTI for a given token amount
+     * @param tokenAmount The amount of ERC20 tokens to withdraw
+     * @return fee           The estimated fee in native COTI (18 decimals)
+     * @return lastUpdated   Oracle data last update timestamp
+     * @return threshold     Staleness cutoff timestamp (0 if disabled)
+     * @return blockTimestamp Current block.timestamp
+     */
+    function estimateWithdrawFee(uint256 tokenAmount) external view override returns (uint256 fee, uint256 lastUpdated, uint256 threshold, uint256 blockTimestamp) {
+        fee = _computeErc20Fee(tokenAmount, withdrawFixedFee, withdrawPercentageBps, withdrawMaxFee);
+        (,lastUpdated, threshold, blockTimestamp) = ICotiPriceConsumer(priceOracle).getPriceWithMeta("COTI");
+    }
+
+    /**
+     * @notice Collect the dynamic native COTI fee from msg.value and refund any excess
+     * @param fee The computed fee in native COTI
+     * @dev Reverts with {InsufficientCotiFee} if msg.value < fee.
+     *      Excess above fee is refunded best-effort; if the refund fails, the excess is
+     *      added to accumulatedCotiFees so it remains recoverable via {withdrawCotiFees}.
+     */
+    function _collectDynamicNativeFee(uint256 fee) internal {
+        if (msg.value < fee) revert InsufficientCotiFee();
+        accumulatedCotiFees += fee;
+        if (msg.value > fee) {
+            uint256 excess = msg.value - fee;
             (bool ok, ) = msg.sender.call{value: excess}("");
             if (!ok) {
-                accumulatedCotiFees += excess; // unrefundable; recoverable via withdrawCotiFees
+                accumulatedCotiFees += excess;
             }
         }
     }
@@ -62,8 +115,9 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
      * @notice Initialize the PrivacyBridgeERC20 contract
      * @param _token Address of the public ERC20 token (must be standard: no fee-on-transfer, no rebasing; same decimals as private token)
      * @param _privateToken Address of the private token
+     * @param _tokenSymbol Band oracle symbol for the bridged token (e.g., "ETH", "WBTC")
      */
-    constructor(address _token, address _privateToken) PrivacyBridge() {
+    constructor(address _token, address _privateToken, string memory _tokenSymbol) PrivacyBridge() {
         if (_token == address(0)) revert InvalidTokenAddress();
         if (_privateToken == address(0)) revert InvalidPrivateTokenAddress();
 
@@ -73,99 +127,99 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
 
         token = IERC20(_token);
         privateToken = IPrivateERC20(_privateToken);
+        tokenSymbol = _tokenSymbol;
     }
 
     /**
      * @notice Deposit public ERC20 tokens to receive equivalent private tokens
      * @param amount Amount of public ERC20 tokens to deposit
-     * @dev Native COTI fee: send msg.value >= nativeCotiFee. Excess is refunded best-effort;
+     * @param oracleTimestamp The oracle lastUpdated timestamp from estimateDepositFee (ensures fee hasn't changed)
+     * @dev Native COTI fee: send msg.value >= computed fee. Excess is refunded best-effort;
      *      if refund fails (e.g. sender cannot receive native token), excess remains in the contract and deposit still succeeds.
-     *      Send exactly nativeCotiFee or ensure sender can receive native token to avoid leaving excess in the contract.
      */
     function deposit(
-        uint256 amount
+        uint256 amount,
+        uint256 oracleTimestamp
     ) external payable nonReentrant whenNotPaused {
-        _deposit(amount);
+        _deposit(amount, oracleTimestamp);
     }
 
-    function _deposit(uint256 amount) internal {
+    function _deposit(uint256 amount, uint256 oracleTimestamp) internal {
         if (!isDepositEnabled) revert DepositDisabled();
         if (amount == 0) revert AmountZero();
+        if (IHasDecimals(address(token)).decimals() != IHasDecimals(address(privateToken)).decimals())
+            revert DecimalsMismatch();
         _checkDepositLimits(amount);
+        _validateOracleTimestamp(oracleTimestamp);
 
-        // Step 1: collect flat native COTI fee (refunds excess to sender)
-        _collectNativeFee();
+        // Step 1: compute dynamic fee in COTI
+        uint256 fee = _computeErc20Fee(amount, depositFixedFee, depositPercentageBps, depositMaxFee);
 
-        // Step 2: pull tokens and measure actual received amount (fee-on-transfer safe)
+        // Step 2: collect fee from msg.value (refunds excess to sender)
+        _collectDynamicNativeFee(fee);
+
+        // Step 3: pull full token amount from user
         uint256 balBefore = token.balanceOf(address(this));
         token.safeTransferFrom(msg.sender, address(this), amount);
         uint256 received = token.balanceOf(address(this)) - balBefore;
 
-        // Step 3: deduct bridged-asset deposit fee, get net amount to mint
-        uint256 amountAfterFee = _collectTokenFee(received, depositFeeBasisPoints);
+        // Step 4: mint full private token amount
+        privateToken.mint(msg.sender, received);
 
-        // Step 4: mint private tokens
-        privateToken.mint(msg.sender, amountAfterFee);
-
-        emit Deposit(msg.sender, received, amountAfterFee);
+        emit Deposit(msg.sender, amount, received);
     }
 
     /**
      * @notice Withdraw public ERC20 tokens by burning private tokens
      * @param amount Amount of private tokens to burn
-     * @dev Requires prior approval on the private token. Native COTI fee: send msg.value >= nativeCotiFee; excess refunded best-effort (see deposit).
+     * @param oracleTimestamp The oracle lastUpdated timestamp from estimateWithdrawFee (ensures fee hasn't changed)
+     * @dev Requires prior approval on the private token. Native COTI fee: send msg.value >= computed fee; excess refunded best-effort.
      */
     function withdraw(
-        uint256 amount
+        uint256 amount,
+        uint256 oracleTimestamp
     ) external payable nonReentrant whenNotPaused {
-        _withdraw(amount);
+        _withdraw(amount, oracleTimestamp);
     }
 
-    function _withdraw(uint256 amount) internal {
+    function _withdraw(uint256 amount, uint256 oracleTimestamp) internal {
         if (amount == 0) revert AmountZero();
+        if (IHasDecimals(address(token)).decimals() != IHasDecimals(address(privateToken)).decimals())
+            revert DecimalsMismatch();
         _checkWithdrawLimits(amount);
+        _validateOracleTimestamp(oracleTimestamp);
 
-        // Step 1: collect flat native COTI fee (refunds excess to sender)
-        _collectNativeFee();
+        // Step 1: compute dynamic fee in COTI
+        uint256 fee = _computeErc20Fee(amount, withdrawFixedFee, withdrawPercentageBps, withdrawMaxFee);
 
-        // Step 2: deduct bridged-asset withdrawal fee, get net amount to release
-        uint256 amountAfterFee = _collectTokenFee(amount, withdrawFeeBasisPoints);
+        // Step 2: collect fee from msg.value (refunds excess to sender)
+        _collectDynamicNativeFee(fee);
 
-        // Step 3: verify bridge has enough liquidity (reserves fee balance)
+        // Step 3: verify bridge has enough liquidity
         uint256 bridgeBalance = token.balanceOf(address(this));
-        if (bridgeBalance < accumulatedFees + amountAfterFee)
+        if (bridgeBalance < amount)
             revert InsufficientBridgeLiquidity();
 
-        // Step 4: pull and burn private tokens
+        // Step 4: pull and burn full private token amount
         privateToken.transferFrom(msg.sender, address(this), amount);
         privateToken.burn(amount);
 
-        // Step 5: release public tokens to user
-        token.safeTransfer(msg.sender, amountAfterFee);
+        // Step 5: release full public token amount to user
+        token.safeTransfer(msg.sender, amount);
 
-        emit Withdraw(msg.sender, amount, amountAfterFee);
+        emit Withdraw(msg.sender, amount, amount);
     }
 
     /**
-     * @notice Withdraw accumulated fees (ERC20 implementation)
-     * @param to Address to send fees to
-     * @param amount Amount of fees to withdraw
-     * @dev Only the owner can call this function
+     * @notice Withdraw accumulated fees — disabled for ERC20 bridges
+     * @dev All fees are now collected in native COTI via accumulatedCotiFees.
+     *      Use withdrawCotiFees() instead. This function always reverts.
      */
     function withdrawFees(
-        address to,
-        uint256 amount
-    ) external override onlyOperator nonReentrant {
-        if (to == address(0)) revert InvalidAddress();
-        if (amount == 0) revert AmountZero();
-        if (amount > accumulatedFees) revert InsufficientAccumulatedFees();
-
-        accumulatedFees -= amount;
-
-        // Transfer public ERC20 tokens
-        token.safeTransfer(to, amount);
-
-        emit FeesWithdrawn(to, amount);
+        address,
+        uint256
+    ) external override onlyOwner nonReentrant {
+        revert WithdrawFeesMustBeOverridden();
     }
 
     /**

--- a/contracts/privacyBridge/PrivacyBridgeUSDCe.sol
+++ b/contracts/privacyBridge/PrivacyBridgeUSDCe.sol
@@ -10,7 +10,7 @@ import "../token/PrivateERC20/tokens/PrivateBridgedUSDC.sol";
  */
 contract PrivacyBridgeUSDCe is PrivacyBridgeERC20 {
 
-    constructor(address _usdc, address _privateUsdc) PrivacyBridgeERC20(_usdc, _privateUsdc) {
+    constructor(address _usdc, address _privateUsdc) PrivacyBridgeERC20(_usdc, _privateUsdc, "USDC") {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeUSDT.sol
+++ b/contracts/privacyBridge/PrivacyBridgeUSDT.sol
@@ -11,7 +11,7 @@ import "../token/PrivateERC20/tokens/PrivateTetherUSD.sol";
 contract PrivacyBridgeUSDT is PrivacyBridgeERC20 {
     
 
-    constructor(address _usdt, address _privateUsdt) PrivacyBridgeERC20(_usdt, _privateUsdt) {
+    constructor(address _usdt, address _privateUsdt) PrivacyBridgeERC20(_usdt, _privateUsdt, "USDT") {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeWADA.sol
+++ b/contracts/privacyBridge/PrivacyBridgeWADA.sol
@@ -11,7 +11,7 @@ import "../token/PrivateERC20/tokens/PrivateWrappedADA.sol";
 contract PrivacyBridgeWADA is PrivacyBridgeERC20 {
     
 
-    constructor(address _wada, address _privateWada) PrivacyBridgeERC20(_wada, _privateWada) {
+    constructor(address _wada, address _privateWada) PrivacyBridgeERC20(_wada, _privateWada, "ADA") {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeWBTC.sol
+++ b/contracts/privacyBridge/PrivacyBridgeWBTC.sol
@@ -11,7 +11,7 @@ import "../token/PrivateERC20/tokens/PrivateWrappedBTC.sol";
 contract PrivacyBridgeWBTC is PrivacyBridgeERC20 {
     
 
-    constructor(address _wbtc, address _privateWbtc) PrivacyBridgeERC20(_wbtc, _privateWbtc) {
+    constructor(address _wbtc, address _privateWbtc) PrivacyBridgeERC20(_wbtc, _privateWbtc, "WBTC") {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeWETH.sol
+++ b/contracts/privacyBridge/PrivacyBridgeWETH.sol
@@ -11,7 +11,7 @@ import "../token/PrivateERC20/tokens/PrivateWrappedEther.sol";
 contract PrivacyBridgeWETH is PrivacyBridgeERC20 {
     
 
-    constructor(address _weth, address _privateWeth) PrivacyBridgeERC20(_weth, _privateWeth) {
+    constructor(address _weth, address _privateWeth) PrivacyBridgeERC20(_weth, _privateWeth, "ETH") {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgegCoti.sol
+++ b/contracts/privacyBridge/PrivacyBridgegCoti.sol
@@ -11,7 +11,7 @@ import "../token/PrivateERC20/tokens/PrivateCOTITreasuryGovernanceToken.sol";
 contract PrivacyBridgegCoti is PrivacyBridgeERC20 {
     
 
-    constructor(address _gCoti, address _privategCoti) PrivacyBridgeERC20(_gCoti, _privategCoti) {
+    constructor(address _gCoti, address _privategCoti) PrivacyBridgeERC20(_gCoti, _privategCoti, "GCOTI") {
         
     }
 }


### PR DESCRIPTION
## Summary

Replaces the old percentage-based bridged-asset fees with a dynamic fee formula charged in native COTI:

```
fee = min(max(fixedFee, percentageOfUsdValue), maxFee)
```

## Changes

### New files
- `contracts/oracle/CotiPriceConsumer.sol` — Band Protocol oracle consumer with staleness checks
- `contracts/oracle/IStdReference.sol` — Band Protocol interface

### Modified files
- `contracts/privacyBridge/PrivacyBridge.sol` — Base contract with dynamic fee state, setters, `estimateDepositFee`/`estimateWithdrawFee` virtual declarations, `withdrawFees`/`withdrawCotiFees` restricted to onlyOwner
- `contracts/privacyBridge/PrivacyBridgeCotiNative.sol` — Native COTI fee computation via oracle
- `contracts/privacyBridge/PrivacyBridgeERC20.sol` — ERC20 fee computation (token→USD→COTI), fee collected from msg.value
- `contracts/privacyBridge/PrivacyBridgeWETH.sol` — Updated constructor (tokenSymbol: "ETH")
- `contracts/privacyBridge/PrivacyBridgeWBTC.sol` — Updated constructor (tokenSymbol: "WBTC")
- `contracts/privacyBridge/PrivacyBridgeUSDT.sol` — Updated constructor (tokenSymbol: "USDT")
- `contracts/privacyBridge/PrivacyBridgeUSDCe.sol` — Updated constructor (tokenSymbol: "USDC")
- `contracts/privacyBridge/PrivacyBridgeWADA.sol` — Updated constructor (tokenSymbol: "ADA")
- `contracts/privacyBridge/PrivacyBridgegCoti.sol` — Updated constructor (tokenSymbol: "GCOTI")

## Default Fee Parameters
| Parameter | Deposit | Withdraw |
|-----------|---------|----------|
| Fixed (floor) | 10 COTI | 3 COTI |
| Percentage | 0.05% (500/1M) | 0.025% (250/1M) |
| Max (cap) | 3,000 COTI | 1,500 COTI |

## Access Control Changes
- `withdrawFees` and `withdrawCotiFees` → `onlyOwner` (previously `onlyOperator`)
- Dynamic fee setters remain `onlyOperator`
- `setPriceOracle` remains `onlyOwner`

## Testing
- 41 tests passing (property-based + unit tests) on local Hardhat
- Deployed and verified on COTI Testnet (chainId 7082400)