### PR TITLE
feat: Dynamic fees v2 with oracle validation

### DIFF
--- a/contracts/oracle/CotiPriceConsumer.sol
+++ b/contracts/oracle/CotiPriceConsumer.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./IStdReference.sol";
+
+/**
+ * @title CotiPriceConsumer
+ * @notice Retrieves token/USD prices from the Band Protocol oracle.
+ * @dev All prices returned by Band Protocol are scaled by 1e18.
+ *      For example, a rate of 50000000000000000 means $0.05.
+ */
+contract CotiPriceConsumer {
+    /// @notice Band Protocol StdReferenceProxy on COTI .
+    IStdReference public immutable ref;
+
+    /// @notice Maximum acceptable age (in seconds) for oracle data before it is considered stale.
+    uint256 public maxStaleness;
+
+    /// @notice Emitted when the staleness threshold is updated.
+    event MaxStalenessUpdated(uint256 oldValue, uint256 newValue);
+
+    /// @notice Thrown when the oracle data is older than the allowed staleness window.
+    error StaleOracleData(uint256 lastUpdated, uint256 threshold);
+
+    address public owner;
+
+    /// @notice Minimum allowed staleness threshold (1 hour).
+    uint256 public constant MIN_STALENESS = 1 hours;
+
+    /// @notice Thrown when the staleness value is below the minimum.
+    error StalenessTooLow(uint256 provided, uint256 minimum);
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "CotiPriceConsumer: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @param _ref          Address of the Band Protocol StdReferenceProxy contract.
+     * @param _maxStaleness Maximum acceptable data age in seconds (0 = no staleness check).
+     */
+    constructor(address _ref, uint256 _maxStaleness) {
+        require(_ref != address(0), "CotiPriceConsumer: zero ref address");
+        if (_maxStaleness < MIN_STALENESS) revert StalenessTooLow(_maxStaleness, MIN_STALENESS);
+        ref = IStdReference(_ref);
+        maxStaleness = _maxStaleness;
+        owner = msg.sender;
+    }
+
+    /// @notice Returns the rate, last update timestamp, and current block timestamp for any base/USD pair.
+    /// @return rate           The price scaled by 1e18
+    /// @return lastUpdated    Block timestamp when the oracle data was last updated
+    /// @return blockTimestamp The current block.timestamp
+    function getPriceWithMeta(string calldata _base) external view returns (uint256 rate, uint256 lastUpdated, uint256 blockTimestamp) {
+        IStdReference.ReferenceData memory data = _getPrice(_base);
+        rate = data.rate;
+        lastUpdated = data.lastUpdatedBase;
+        blockTimestamp = block.timestamp;
+    }
+
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Internal helper
+    // ──────────────────────────────────────────────────────────────────────
+
+    /**
+     * @dev Queries the Band oracle for `_base`/USD and optionally enforces staleness.
+     */
+    function _getPrice(string memory _base) internal view returns (IStdReference.ReferenceData memory data) {
+        data = ref.getReferenceData(_base, "USD");
+
+        uint256 threshold = block.timestamp - maxStaleness;
+        if (data.lastUpdatedBase < threshold) {
+            revert StaleOracleData(data.lastUpdatedBase, threshold);
+        }
+    }
+
+
+    // ──────────────────────────────────────────────────────────────────────
+    //  Generic getter — query any symbol the oracle supports
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// @notice Returns the rate for an arbitrary base/USD pair scaled by 1e18.
+    function getPrice(string calldata _base) external view returns (uint256) {
+        return _getPrice(_base).rate;
+    }
+
+
+    /// @notice Returns the full ReferenceData for an arbitrary base/USD pair.
+    function getPriceData(string calldata _base) external view returns (IStdReference.ReferenceData memory) {
+        return _getPrice(_base);
+    }
+
+    /**
+     * @notice Updates the maximum staleness threshold.
+     * @param _maxStaleness New threshold in seconds (0 = disable check).
+     */
+    function setMaxStaleness(uint256 _maxStaleness) external onlyOwner {
+        if (_maxStaleness < MIN_STALENESS) revert StalenessTooLow(_maxStaleness, MIN_STALENESS);
+        emit MaxStalenessUpdated(maxStaleness, _maxStaleness);
+        maxStaleness = _maxStaleness;
+    }
+}

--- a/contracts/oracle/ICotiPriceConsumer.sol
+++ b/contracts/oracle/ICotiPriceConsumer.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+/**
+ * @title ICotiPriceConsumer
+ * @notice Minimal interface for the CotiPriceConsumer oracle used by the bridge
+ */
+interface ICotiPriceConsumer {
+   
+    /// @notice Returns the rate for an arbitrary base/USD pair scaled by 1e18.
+    function getPrice(string calldata _base) external view returns (uint256);
+
+    /// @notice Returns rate + metadata for any base/USD pair.
+    function getPriceWithMeta(string calldata _base) external view returns (uint256 rate, uint256 lastUpdated, uint256 blockTimestamp);
+}

--- a/contracts/oracle/IStdReference.sol
+++ b/contracts/oracle/IStdReference.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title IStdReference
+ * @notice Band Protocol Standard Reference interface for querying price data.
+ */
+interface IStdReference {
+    struct ReferenceData {
+        uint256 rate;            // base/quote exchange rate, scaled by 1e18
+        uint256 lastUpdatedBase; // UNIX epoch when the base price was last updated
+        uint256 lastUpdatedQuote; // UNIX epoch when the quote price was last updated
+    }
+
+    /// @notice Returns the price data for a single base/quote pair.
+    function getReferenceData(
+        string memory _base,
+        string memory _quote
+    ) external view returns (ReferenceData memory);
+
+    /// @notice Returns the price data for multiple base/quote pairs.
+    function getReferenceDataBulk(
+        string[] memory _bases,
+        string[] memory _quotes
+    ) external view returns (ReferenceData[] memory);
+}

--- a/contracts/privacyBridge/PrivacyBridge.sol
+++ b/contracts/privacyBridge/PrivacyBridge.sol
@@ -143,12 +143,15 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     /// @notice Emitted when accumulated fees are withdrawn
     event FeesWithdrawn(address indexed to, uint256 amount);
 
-    constructor() Ownable() {
+    constructor(address _feeRecipient, address _rescueRecipient) Ownable() {
+        if (_feeRecipient == address(0)) revert InvalidAddress();
+        if (_rescueRecipient == address(0)) revert InvalidAddress();
         maxDepositAmount = type(uint256).max;
         maxWithdrawAmount = type(uint256).max;
         minDepositAmount = 1;
         minWithdrawAmount = 1;
-        rescueRecipient = msg.sender;
+        feeRecipient = _feeRecipient;
+        rescueRecipient = _rescueRecipient;
 
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(OPERATOR_ROLE, msg.sender);
@@ -397,34 +400,6 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
         address oldOracle = priceOracle;
         priceOracle = _oracle;
         emit PriceOracleUpdated(oldOracle, _oracle);
-    }
-
-    event FeeRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
-
-    /**
-     * @notice Set the address where collected fees are sent
-     * @param _recipient Address to receive fees
-     * @dev Only the owner can call this function
-     */
-    function setFeeRecipient(address _recipient) external onlyOwner {
-        if (_recipient == address(0)) revert InvalidAddress();
-        address old = feeRecipient;
-        feeRecipient = _recipient;
-        emit FeeRecipientUpdated(old, _recipient);
-    }
-
-    event RescueRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
-
-    /**
-     * @notice Set the address where rescued funds are sent
-     * @param _recipient Address to receive rescued funds
-     * @dev Only the owner can call this function
-     */
-    function setRescueRecipient(address _recipient) external onlyOwner {
-        if (_recipient == address(0)) revert InvalidAddress();
-        address old = rescueRecipient;
-        rescueRecipient = _recipient;
-        emit RescueRecipientUpdated(old, _recipient);
     }
 
 

--- a/contracts/privacyBridge/PrivacyBridge.sol
+++ b/contracts/privacyBridge/PrivacyBridge.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/security/Pausable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
+import "../oracle/ICotiPriceConsumer.sol";
 
 /**
  * @title PrivacyBridge
@@ -22,6 +23,8 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     event OperatorRemoved(address indexed account, address indexed by);
     event DepositEnabledUpdated(bool enabled, address indexed by);
     event NativeCotiFeeUpdated(uint256 fee, address indexed by);
+    event DynamicFeeUpdated(string feeType, uint256 fixedFee, uint256 percentageBps, uint256 maxFee);
+    event PriceOracleUpdated(address indexed oldOracle, address indexed newOracle);
 
     /// @notice Maximum amount that can be deposited in a single transaction
     uint256 public maxDepositAmount;
@@ -59,6 +62,40 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     /// @notice Fee in native COTI for bridge operations
     uint256 public nativeCotiFee;
 
+
+    // Privacy Bridge defines default Fees
+    // those fees can be overwritten using
+    // setDepositDynamicFee available for OPERATORS and ADMIN
+
+    /// @notice Deposit fee floor in COTI wei
+    uint256 public depositFixedFee = 10 ether;
+
+    /// @notice Deposit percentage (500/1,000,000 = 0.05%)
+    uint256 public depositPercentageBps = 500;
+
+    /// @notice Deposit fee cap in COTI wei
+    uint256 public depositMaxFee = 3000 ether;
+
+    /// @notice Withdraw fee floor in COTI wei
+    uint256 public withdrawFixedFee = 3 ether;
+
+    /// @notice Withdraw percentage (250/1,000,000 = 0.025%)
+    uint256 public withdrawPercentageBps = 250;
+
+    /// @notice Withdraw fee cap in COTI wei
+    uint256 public withdrawMaxFee = 1500 ether;
+
+    // --- END OF DEFAULT FEES
+
+    /// @notice CotiPriceConsumer contract address
+    address public priceOracle;
+
+    /// @notice Address where collected fees are sent
+    address public feeRecipient;
+
+    /// @notice Address where rescued funds are sent
+    address public rescueRecipient;
+
     error AmountZero();
     error InsufficientEthBalance();
     error EthTransferFailed();
@@ -66,6 +103,8 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     error DepositDisabled();
     error InsufficientCotiFee();
     error BridgePaused();
+    error OracleTimestampMismatch(uint256 expected, uint256 actual);
+    error FeeRecipientNotSet();
 
     // Limits errors
     error InvalidLimitConfiguration();
@@ -74,6 +113,7 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     error WithdrawBelowMinimum();
     error WithdrawExceedsMaximum();
     error InvalidFee();
+    error InvalidFeeConfiguration();
     error InsufficientAccumulatedFees();
     error WithdrawFeesMustBeOverridden();
 
@@ -108,6 +148,7 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
         maxWithdrawAmount = type(uint256).max;
         minDepositAmount = 1;
         minWithdrawAmount = 1;
+        rescueRecipient = msg.sender;
 
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
         _grantRole(OPERATOR_ROLE, msg.sender);
@@ -263,6 +304,129 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
         emit NativeCotiFeeUpdated(_fee, msg.sender);
     }
 
+    /**
+     * @notice Validate oracle timestamps for both COTI and a bridged token.
+     * @dev Used by ERC20 bridges where the fee depends on two oracle prices.
+     * @param expectedCotiTimestamp The COTI lastUpdated from the estimate call.
+     * @param expectedTokenTimestamp The token lastUpdated from the estimate call.
+     * @param tokenSymbol The Band oracle symbol for the bridged token.
+     */
+    function _validateOracleTimestamps(
+        uint256 expectedCotiTimestamp,
+        uint256 expectedTokenTimestamp,
+        string memory tokenSymbol
+    ) internal view {
+        (, uint256 cotiLastUpdated,) = ICotiPriceConsumer(priceOracle).getPriceWithMeta("COTI");
+        if (cotiLastUpdated != expectedCotiTimestamp) revert OracleTimestampMismatch(expectedCotiTimestamp, cotiLastUpdated);
+        (, uint256 tokenLastUpdated,) = ICotiPriceConsumer(priceOracle).getPriceWithMeta(tokenSymbol);
+        if (tokenLastUpdated != expectedTokenTimestamp) revert OracleTimestampMismatch(expectedTokenTimestamp, tokenLastUpdated);
+    }
+
+    /**
+     * @notice Calculate the dynamic fee using the floor/cap formula
+     * @param percentageFeeCoti The percentage-based fee component in COTI
+     * @param fixedFee The minimum fee floor in COTI
+     * @param maxFee The maximum fee cap in COTI
+     * @return The computed fee: min(max(fixedFee, percentageFeeCoti), maxFee)
+     */
+    function _calculateDynamicFee(
+        uint256 percentageFeeCoti,
+        uint256 fixedFee,
+        uint256 maxFee
+    ) internal pure returns (uint256) {
+        uint256 fee = percentageFeeCoti > fixedFee ? percentageFeeCoti : fixedFee;
+        return fee > maxFee ? maxFee : fee;
+    }
+
+    /**
+     * @notice Estimate functions are declared in derived contracts (Native and ERC20 bridges)
+     *         with different return signatures:
+     *         - Native: returns (fee, lastUpdated, blockTimestamp)
+     *         - ERC20:  returns (fee, cotiLastUpdated, tokenLastUpdated, blockTimestamp)
+     */
+
+    /**
+     * @notice Set the deposit dynamic fee parameters
+     * @param _fixedFee New deposit fee floor in COTI wei
+     * @param _percentageBps New deposit percentage (max MAX_FEE_UNITS = 10%)
+     * @param _maxFee New deposit fee cap in COTI wei
+     * @dev Only the operator can call this function
+     */
+    function setDepositDynamicFee(
+        uint256 _fixedFee,
+        uint256 _percentageBps,
+        uint256 _maxFee
+    ) external onlyOperator {
+        if (_maxFee == 0) revert InvalidFeeConfiguration();
+        if (_fixedFee > _maxFee) revert InvalidFeeConfiguration();
+        if (_percentageBps > MAX_FEE_UNITS) revert InvalidFee();
+        depositFixedFee = _fixedFee;
+        depositPercentageBps = _percentageBps;
+        depositMaxFee = _maxFee;
+        emit DynamicFeeUpdated("deposit", _fixedFee, _percentageBps, _maxFee);
+    }
+
+    /**
+     * @notice Set the withdraw dynamic fee parameters
+     * @param _fixedFee New withdraw fee floor in COTI wei
+     * @param _percentageBps New withdraw percentage (max MAX_FEE_UNITS = 10%)
+     * @param _maxFee New withdraw fee cap in COTI wei
+     * @dev Only the operator can call this function
+     */
+    function setWithdrawDynamicFee(
+        uint256 _fixedFee,
+        uint256 _percentageBps,
+        uint256 _maxFee
+    ) external onlyOperator {
+        if (_maxFee == 0) revert InvalidFeeConfiguration();
+        if (_fixedFee > _maxFee) revert InvalidFeeConfiguration();
+        if (_percentageBps > MAX_FEE_UNITS) revert InvalidFee();
+        withdrawFixedFee = _fixedFee;
+        withdrawPercentageBps = _percentageBps;
+        withdrawMaxFee = _maxFee;
+        emit DynamicFeeUpdated("withdraw", _fixedFee, _percentageBps, _maxFee);
+    }
+
+    /**
+     * @notice Set the price oracle address
+     * @param _oracle Address of the CotiPriceConsumer contract
+     * @dev Only the owner can call this function
+     */
+    function setPriceOracle(address _oracle) external onlyOwner {
+        if (_oracle == address(0)) revert InvalidAddress();
+        address oldOracle = priceOracle;
+        priceOracle = _oracle;
+        emit PriceOracleUpdated(oldOracle, _oracle);
+    }
+
+    event FeeRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
+
+    /**
+     * @notice Set the address where collected fees are sent
+     * @param _recipient Address to receive fees
+     * @dev Only the owner can call this function
+     */
+    function setFeeRecipient(address _recipient) external onlyOwner {
+        if (_recipient == address(0)) revert InvalidAddress();
+        address old = feeRecipient;
+        feeRecipient = _recipient;
+        emit FeeRecipientUpdated(old, _recipient);
+    }
+
+    event RescueRecipientUpdated(address indexed oldRecipient, address indexed newRecipient);
+
+    /**
+     * @notice Set the address where rescued funds are sent
+     * @param _recipient Address to receive rescued funds
+     * @dev Only the owner can call this function
+     */
+    function setRescueRecipient(address _recipient) external onlyOwner {
+        if (_recipient == address(0)) revert InvalidAddress();
+        address old = rescueRecipient;
+        rescueRecipient = _recipient;
+        emit RescueRecipientUpdated(old, _recipient);
+    }
+
 
     /**
      * @notice Calculate fee amount based on the input amount and fee basis points
@@ -296,17 +460,15 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     }
 
     /**
-     * @notice Withdraw accumulated fees
-     * @param to Address to send the fees to
+     * @notice Withdraw accumulated fees to the predefined feeRecipient
      * @param amount Amount of fees to withdraw
-     * @dev Only the operator can call this function. Must be overridden in derived contracts
+     * @dev Only the owner can call this function. Must be overridden in derived contracts
      *      to perform the actual token/native transfer; base implementation reverts.
      */
     function withdrawFees(
-        address to,
         uint256 amount
-    ) external virtual onlyOperator {
-        if (to == address(0)) revert InvalidAddress();
+    ) external virtual onlyOwner {
+        if (feeRecipient == address(0)) revert FeeRecipientNotSet();
         if (amount == 0) revert AmountZero();
         if (amount > accumulatedFees) revert InsufficientAccumulatedFees();
         revert WithdrawFeesMustBeOverridden();
@@ -315,23 +477,21 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     event CotiFeesWithdrawn(address indexed to, uint256 amount);
 
     /**
-     * @notice Withdraw accumulated native COTI fees
-     * @param to Address to send the native COTI fees to
+     * @notice Withdraw accumulated native COTI fees to the predefined feeRecipient
      * @param amount Amount of native COTI fees to withdraw
-     * @dev Only the operator can call this function. Derived ERC20 bridges use this inherited implementation to withdraw
-     *      accumulated native COTI fees; native bridge does not use this (accumulatedCotiFees remains 0).
+     * @dev Only the owner can call this function.
      */
-    function withdrawCotiFees(address to, uint256 amount) external onlyOperator nonReentrant {
-        if (to == address(0)) revert InvalidAddress();
+    function withdrawCotiFees(uint256 amount) external onlyOwner nonReentrant {
+        if (feeRecipient == address(0)) revert FeeRecipientNotSet();
         if (amount == 0) revert AmountZero();
         if (amount > accumulatedCotiFees) revert InsufficientAccumulatedFees();
         if (amount > address(this).balance) revert InsufficientEthBalance();
 
         accumulatedCotiFees -= amount;
 
-        (bool success, ) = to.call{value: amount}("");
+        (bool success, ) = feeRecipient.call{value: amount}("");
         if (!success) revert EthTransferFailed();
 
-        emit CotiFeesWithdrawn(to, amount);
+        emit CotiFeesWithdrawn(feeRecipient, amount);
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
+++ b/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
@@ -23,7 +23,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
      * @notice Initialize the Native Bridge
      * @param _privateCoti Address of the PrivateCoti token contract
      */
-    constructor(address _privateCoti) PrivacyBridge() {
+    constructor(address _privateCoti, address _feeRecipient, address _rescueRecipient) PrivacyBridge(_feeRecipient, _rescueRecipient) {
         if (_privateCoti == address(0)) revert InvalidAddress();
         privateCoti = PrivateCOTI(_privateCoti);
     }

--- a/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
+++ b/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
@@ -29,55 +29,111 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
     }
 
     /**
+     * @notice Compute the dynamic fee in native COTI
+     * @param cotiAmount The COTI amount to compute fee for
+     * @param fixedFee The minimum fee floor in COTI wei
+     * @param percentageBps The percentage in basis points (relative to FEE_DIVISOR)
+     * @param maxFee The maximum fee cap in COTI wei
+     * @return The computed fee in COTI wei
+     */
+    function _computeCotiFee(
+        uint256 cotiAmount,
+        uint256 fixedFee,
+        uint256 percentageBps,
+        uint256 maxFee
+    ) internal view returns (uint256) {
+        uint256 cotiUsdRate = ICotiPriceConsumer(priceOracle).getPrice("COTI");
+        uint256 txValueUsd = (cotiAmount * cotiUsdRate) / 1e18;
+        uint256 percentageFeeUsd = (txValueUsd * percentageBps) / FEE_DIVISOR;
+        uint256 percentageFeeCoti = (percentageFeeUsd * 1e18) / cotiUsdRate;
+        return _calculateDynamicFee(percentageFeeCoti, fixedFee, maxFee);
+    }
+
+    /**
+     * @notice Estimate the deposit fee in COTI for a given COTI amount
+     * @param cotiAmount The amount of native COTI to deposit
+     * @return fee                The estimated fee in COTI wei
+     * @return cotiLastUpdated    COTI oracle data last update timestamp
+     * @return blockTimestamp     Current block.timestamp
+     */
+    function estimateDepositFee(uint256 cotiAmount) external view returns (uint256 fee, uint256 cotiLastUpdated, uint256 blockTimestamp) {
+        fee = _computeCotiFee(cotiAmount, depositFixedFee, depositPercentageBps, depositMaxFee);
+        (,cotiLastUpdated, blockTimestamp) = ICotiPriceConsumer(priceOracle).getPriceWithMeta("COTI");
+    }
+
+    /**
+     * @notice Estimate the withdrawal fee in COTI for a given COTI amount
+     * @param cotiAmount The amount of native COTI to withdraw
+     * @return fee                The estimated fee in COTI wei
+     * @return cotiLastUpdated    COTI oracle data last update timestamp
+     * @return blockTimestamp     Current block.timestamp
+     */
+    function estimateWithdrawFee(uint256 cotiAmount) external view returns (uint256 fee, uint256 cotiLastUpdated, uint256 blockTimestamp) {
+        fee = _computeCotiFee(cotiAmount, withdrawFixedFee, withdrawPercentageBps, withdrawMaxFee);
+        (,cotiLastUpdated, blockTimestamp) = ICotiPriceConsumer(priceOracle).getPriceWithMeta("COTI");
+    }
+
+    /**
      * @notice Internal function to handle deposits
      * @param sender Address of the depositor
      */
-    function _deposit(address sender) internal {
+    function _deposit(address sender, uint256 cotiOracleTimestamp, uint256 tokenOracleTimestamp) internal {
         if (!isDepositEnabled) revert DepositDisabled();
         if (msg.value == 0) revert AmountZero();
 
         _checkDepositLimits(msg.value);
+        _validateOracleTimestamps(cotiOracleTimestamp, tokenOracleTimestamp, "COTI");
 
-        // Deduct bridged-asset deposit fee, get net amount to mint
-        uint256 amountAfterFee = _collectTokenFee(msg.value, depositFeeBasisPoints);
+        // Compute dynamic fee in COTI
+        uint256 fee = _computeCotiFee(msg.value, depositFixedFee, depositPercentageBps, depositMaxFee);
+        uint256 netAmount = msg.value - fee;
+        if (netAmount == 0) revert AmountZero();
 
-        privateCoti.mint(sender, amountAfterFee);
+        accumulatedCotiFees += fee;
+
+        privateCoti.mint(sender, netAmount);
 
         // Emit gross deposit amount and net private tokens minted
-        emit Deposit(sender, msg.value, amountAfterFee);
+        emit Deposit(sender, msg.value, netAmount);
     }
 
     /**
      * @notice Deposit native COTI to receive private COTI (COTI.p)
+     * @param cotiOracleTimestamp The COTI oracle lastUpdated timestamp from estimateDepositFee
+     * @param tokenOracleTimestamp The token oracle lastUpdated timestamp (same as cotiOracleTimestamp for native bridge)
      * @dev User sends native COTI with the transaction
      */
-    function deposit() external payable nonReentrant whenNotPaused {
-        _deposit(msg.sender);
+    function deposit(uint256 cotiOracleTimestamp, uint256 tokenOracleTimestamp) external payable nonReentrant whenNotPaused {
+        _deposit(msg.sender, cotiOracleTimestamp, tokenOracleTimestamp);
     }
 
     /**
-     * @notice Withdraw native COTI by burning private COTI
-     * @param amount Amount of private COTI to burn
-     * @dev User must have approved the bridge to spend their private tokens.
-     */
-    /**
      * @notice Handle callback from PrivateCoti.transferAndCall
-     * @dev Called when user transfers tokens to the bridge to withdraw. Third parameter (data) is required by ITokenReceiver but unused.
+     * @dev Called when user transfers tokens to the bridge to withdraw.
+     *      The `data` parameter must be abi-encoded (uint256 cotiOracleTimestamp, uint256 tokenOracleTimestamp).
      * @param from Address of the sender
      * @param amount Amount of tokens received
+     * @param data ABI-encoded (uint256, uint256) oracle timestamps from estimateWithdrawFee
      */
     function onTokenReceived(
         address from,
         uint256 amount,
-        bytes calldata
+        bytes calldata data
     ) external nonReentrant whenNotPaused returns (bool) {
         if (msg.sender != address(privateCoti)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
 
+        (uint256 cotiOracleTimestamp, uint256 tokenOracleTimestamp) = abi.decode(data, (uint256, uint256));
+        _validateOracleTimestamps(cotiOracleTimestamp, tokenOracleTimestamp, "COTI");
+
         _checkWithdrawLimits(amount);
 
-        // Deduct bridged-asset withdrawal fee, get net amount to release
-        uint256 publicAmount = _collectTokenFee(amount, withdrawFeeBasisPoints);
+        // Compute dynamic withdrawal fee in COTI
+        uint256 fee = _computeCotiFee(amount, withdrawFixedFee, withdrawPercentageBps, withdrawMaxFee);
+        uint256 publicAmount = amount - fee;
+        if (publicAmount == 0) revert AmountZero();
+
+        accumulatedCotiFees += fee;
 
         if (address(this).balance < publicAmount)
             revert InsufficientEthBalance();
@@ -97,21 +153,30 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
     /**
      * @notice Withdraw native COTI by burning private COTI
      * @param amount Amount of private COTI to burn
+     * @param cotiOracleTimestamp The COTI oracle lastUpdated timestamp from estimateWithdrawFee
+     * @param tokenOracleTimestamp The token oracle lastUpdated timestamp (same as cotiOracleTimestamp for native bridge)
      * @dev User must have approved the bridge to spend their private tokens.
      */
-    function withdraw(uint256 amount) external nonReentrant whenNotPaused {
-        _withdraw(msg.sender, amount);
+    function withdraw(uint256 amount, uint256 cotiOracleTimestamp, uint256 tokenOracleTimestamp) external nonReentrant whenNotPaused {
+        _withdraw(msg.sender, amount, cotiOracleTimestamp, tokenOracleTimestamp);
     }
 
     function _withdraw(
         address to,
-        uint256 amount
+        uint256 amount,
+        uint256 cotiOracleTimestamp,
+        uint256 tokenOracleTimestamp
     ) internal {
         if (amount == 0) revert AmountZero();
         _checkWithdrawLimits(amount);
+        _validateOracleTimestamps(cotiOracleTimestamp, tokenOracleTimestamp, "COTI");
 
-        // Deduct bridged-asset withdrawal fee, get net amount to release
-        uint256 publicAmount = _collectTokenFee(amount, withdrawFeeBasisPoints);
+        // Compute dynamic withdrawal fee in COTI
+        uint256 fee = _computeCotiFee(amount, withdrawFixedFee, withdrawPercentageBps, withdrawMaxFee);
+        uint256 publicAmount = amount - fee;
+        if (publicAmount == 0) revert AmountZero();
+
+        accumulatedCotiFees += fee;
 
         if (address(this).balance < publicAmount)
             revert InsufficientEthBalance();
@@ -131,10 +196,34 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
     }
 
     /**
-     * @notice Fallback function to handle direct COTI transfers as deposits
+     * @notice Internal deposit without oracle timestamp validation.
+     * @dev Used by receive() for direct COTI transfers. Fee is computed at current oracle price
+     *      without checking that the price hasn't changed since an estimate call.
+     */
+    function _directDeposit(address sender) internal {
+        if (!isDepositEnabled) revert DepositDisabled();
+        if (msg.value == 0) revert AmountZero();
+
+        _checkDepositLimits(msg.value);
+
+        uint256 fee = _computeCotiFee(msg.value, depositFixedFee, depositPercentageBps, depositMaxFee);
+        uint256 netAmount = msg.value - fee;
+        if (netAmount == 0) revert AmountZero();
+
+        accumulatedCotiFees += fee;
+
+        privateCoti.mint(sender, netAmount);
+
+        emit Deposit(sender, msg.value, netAmount);
+    }
+
+    /**
+     * @notice Fallback function to handle direct COTI transfers as deposits.
+     * @dev Mints private tokens at current oracle price without timestamp validation.
+     *      For fee-protected deposits, use deposit(cotiOracleTimestamp, tokenOracleTimestamp) instead.
      */
     receive() external payable nonReentrant whenNotPaused {
-        _deposit(msg.sender);
+        _directDeposit(msg.sender);
     }
 
     /**
@@ -146,49 +235,44 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
     }
 
     /**
-     * @notice Withdraw accumulated fees (Native implementation)
-     * @param to Address to send fees to
+     * @notice Withdraw accumulated fees to feeRecipient (Native implementation)
      * @param amount Amount of fees to withdraw
      * @dev Only the owner can call this function
      */
     function withdrawFees(
-        address to,
         uint256 amount
-    ) external override onlyOperator nonReentrant {
-        if (to == address(0)) revert InvalidAddress();
+    ) external override onlyOwner nonReentrant {
+        if (feeRecipient == address(0)) revert FeeRecipientNotSet();
         if (amount == 0) revert AmountZero();
-        if (amount > accumulatedFees) revert InsufficientAccumulatedFees();
+        if (amount > accumulatedCotiFees) revert InsufficientAccumulatedFees();
         if (amount > address(this).balance) revert InsufficientEthBalance();
 
-        accumulatedFees -= amount;
+        accumulatedCotiFees -= amount;
 
-        // Transfer native COTI tokens
-        (bool success, ) = to.call{value: amount}("");
+        // Transfer native COTI tokens to feeRecipient
+        (bool success, ) = feeRecipient.call{value: amount}("");
         if (!success) revert EthTransferFailed();
 
-        emit FeesWithdrawn(to, amount);
+        emit FeesWithdrawn(feeRecipient, amount);
     }
 
     /**
      * @dev Rescue native COTI coins mistakenly sent to the contract.
      *      Only excess over the accumulated fee reserve can be rescued.
-     *      Owner must NOT rescue amounts that would remove liquidity needed for user withdrawals;
-     *      doing so would break withdraw() and onTokenReceived() until new deposits restore balance.
-     * @param to Address to send the coins to
+     *      Sends to the predefined rescueRecipient address.
      * @param amount Amount of coins to rescue
      * @notice Only the owner can call this function
      */
-    function rescueNative(address to, uint256 amount) external onlyOwner nonReentrant {
-        if (to == address(0)) revert InvalidAddress();
+    function rescueNative(uint256 amount) external onlyOwner nonReentrant {
         if (amount == 0) revert AmountZero();
         if (amount > address(this).balance) revert InsufficientEthBalance();
         if (address(this).balance < accumulatedFees) revert InsufficientEthBalance();
         if (amount > address(this).balance - accumulatedFees) revert ExceedsRescueableAmount();
 
-        (bool success, ) = to.call{value: amount}("");
+        (bool success, ) = rescueRecipient.call{value: amount}("");
         if (!success) revert EthTransferFailed();
 
-        emit NativeRescued(to, amount);
+        emit NativeRescued(rescueRecipient, amount);
     }
 
     /**

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -119,7 +119,7 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
      * @param _privateToken Address of the private token
      * @param _tokenSymbol Band oracle symbol for the bridged token (e.g., "ETH", "WBTC") — required for Band Protocol compatibility check
      */
-    constructor(address _token, address _privateToken, string memory _tokenSymbol) PrivacyBridge() {
+    constructor(address _token, address _privateToken, string memory _tokenSymbol, address _feeRecipient, address _rescueRecipient) PrivacyBridge(_feeRecipient, _rescueRecipient) {
         if (_token == address(0)) revert InvalidTokenAddress();
         if (_privateToken == address(0)) revert InvalidPrivateTokenAddress();
 

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -25,6 +25,9 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
     /// @notice Private token contract being minted/burned
     IPrivateERC20 public privateToken;
 
+    /// @notice Band oracle symbol for the bridged token (e.g., "ETH", "WBTC", "ADA", "USDC", "USDT")
+    string public tokenSymbol;
+
     error InvalidTokenAddress();
     error InvalidPrivateTokenAddress();
     error CannotRescueBridgeToken();
@@ -40,20 +43,72 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
     event ERC20Rescued(address indexed token, address indexed to, uint256 amount);
 
     /**
-     * @notice Collects the flat native COTI per-operation fee from msg.value and refunds any excess to the sender.
-     * @dev Reverts with {InsufficientCotiFee} if msg.value < nativeCotiFee.
-     *      Excess above nativeCotiFee is refunded best-effort; if the refund fails (e.g. sender is a
-     *      contract that cannot receive native tokens), the excess is added to accumulatedCotiFees so
-     *      it remains recoverable via {withdrawCotiFees} rather than being permanently stranded.
+     * @notice Compute the dynamic fee in COTI for an ERC20 bridge operation
+     * @param tokenAmount The amount of ERC20 tokens being bridged
+     * @param fixedFee The minimum fee floor in COTI
+     * @param percentageBps The percentage in basis points (relative to FEE_DIVISOR)
+     * @param maxFee The maximum fee cap in COTI
+     * @return The computed fee in native COTI (18 decimals)
      */
-    function _collectNativeFee() internal {
-        if (msg.value < nativeCotiFee) revert InsufficientCotiFee();
-        accumulatedCotiFees += nativeCotiFee;
-        if (msg.value > nativeCotiFee) {
-            uint256 excess = msg.value - nativeCotiFee;
+    function _computeErc20Fee(
+        uint256 tokenAmount,
+        uint256 fixedFee,
+        uint256 percentageBps,
+        uint256 maxFee
+    ) internal view returns (uint256) {
+        ICotiPriceConsumer oracle = ICotiPriceConsumer(priceOracle);
+        uint256 tokenUsdRate = oracle.getPrice(tokenSymbol);
+        uint256 cotiUsdRate = oracle.getPrice("COTI");
+        uint8 tokenDecimals = IHasDecimals(address(token)).decimals();
+        uint256 txValueUsd = (tokenAmount * tokenUsdRate) / (10 ** tokenDecimals);
+        uint256 percentageFeeUsd = (txValueUsd * percentageBps) / FEE_DIVISOR;
+        uint256 percentageFeeCoti = (percentageFeeUsd * 1e18) / cotiUsdRate;
+        return _calculateDynamicFee(percentageFeeCoti, fixedFee, maxFee);
+    }
+
+    /**
+     * @notice Estimate the deposit fee in COTI for a given token amount
+     * @param tokenAmount The amount of ERC20 tokens to deposit
+     * @return fee                The estimated fee in native COTI (18 decimals)
+     * @return cotiLastUpdated    COTI oracle data last update timestamp
+     * @return tokenLastUpdated   Token oracle data last update timestamp
+     * @return blockTimestamp     Current block.timestamp
+     */
+    function estimateDepositFee(uint256 tokenAmount) external view returns (uint256 fee, uint256 cotiLastUpdated, uint256 tokenLastUpdated, uint256 blockTimestamp) {
+        fee = _computeErc20Fee(tokenAmount, depositFixedFee, depositPercentageBps, depositMaxFee);
+        (,cotiLastUpdated, blockTimestamp) = ICotiPriceConsumer(priceOracle).getPriceWithMeta("COTI");
+        (,tokenLastUpdated,) = ICotiPriceConsumer(priceOracle).getPriceWithMeta(tokenSymbol);
+    }
+
+    /**
+     * @notice Estimate the withdrawal fee in COTI for a given token amount
+     * @param tokenAmount The amount of ERC20 tokens to withdraw
+     * @return fee                The estimated fee in native COTI (18 decimals)
+     * @return cotiLastUpdated    COTI oracle data last update timestamp
+     * @return tokenLastUpdated   Token oracle data last update timestamp
+     * @return blockTimestamp     Current block.timestamp
+     */
+    function estimateWithdrawFee(uint256 tokenAmount) external view returns (uint256 fee, uint256 cotiLastUpdated, uint256 tokenLastUpdated, uint256 blockTimestamp) {
+        fee = _computeErc20Fee(tokenAmount, withdrawFixedFee, withdrawPercentageBps, withdrawMaxFee);
+        (,cotiLastUpdated, blockTimestamp) = ICotiPriceConsumer(priceOracle).getPriceWithMeta("COTI");
+        (,tokenLastUpdated,) = ICotiPriceConsumer(priceOracle).getPriceWithMeta(tokenSymbol);
+    }
+
+    /**
+     * @notice Collect the dynamic native COTI fee from msg.value and refund any excess
+     * @param fee The computed fee in native COTI
+     * @dev Reverts with {InsufficientCotiFee} if msg.value < fee.
+     *      Excess above fee is refunded best-effort; if the refund fails, the excess is
+     *      added to accumulatedCotiFees so it remains recoverable via {withdrawCotiFees}.
+     */
+    function _collectDynamicNativeFee(uint256 fee) internal {
+        if (msg.value < fee) revert InsufficientCotiFee();
+        accumulatedCotiFees += fee;
+        if (msg.value > fee) {
+            uint256 excess = msg.value - fee;
             (bool ok, ) = msg.sender.call{value: excess}("");
             if (!ok) {
-                accumulatedCotiFees += excess; // unrefundable; recoverable via withdrawCotiFees
+                accumulatedCotiFees += excess;
             }
         }
     }
@@ -62,8 +117,9 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
      * @notice Initialize the PrivacyBridgeERC20 contract
      * @param _token Address of the public ERC20 token (must be standard: no fee-on-transfer, no rebasing; same decimals as private token)
      * @param _privateToken Address of the private token
+     * @param _tokenSymbol Band oracle symbol for the bridged token (e.g., "ETH", "WBTC") — required for Band Protocol compatibility check
      */
-    constructor(address _token, address _privateToken) PrivacyBridge() {
+    constructor(address _token, address _privateToken, string memory _tokenSymbol) PrivacyBridge() {
         if (_token == address(0)) revert InvalidTokenAddress();
         if (_privateToken == address(0)) revert InvalidPrivateTokenAddress();
 
@@ -73,117 +129,108 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
 
         token = IERC20(_token);
         privateToken = IPrivateERC20(_privateToken);
+        tokenSymbol = _tokenSymbol;
     }
 
     /**
      * @notice Deposit public ERC20 tokens to receive equivalent private tokens
      * @param amount Amount of public ERC20 tokens to deposit
-     * @dev Native COTI fee: send msg.value >= nativeCotiFee. Excess is refunded best-effort;
-     *      if refund fails (e.g. sender cannot receive native token), excess remains in the contract and deposit still succeeds.
-     *      Send exactly nativeCotiFee or ensure sender can receive native token to avoid leaving excess in the contract.
+     * @param cotiOracleTimestamp The COTI oracle lastUpdated timestamp from estimateDepositFee
+     * @param tokenOracleTimestamp The token oracle lastUpdated timestamp from estimateDepositFee
+     * @dev Native COTI fee: send msg.value >= computed fee. Excess is refunded best-effort.
      */
     function deposit(
-        uint256 amount
+        uint256 amount,
+        uint256 cotiOracleTimestamp,
+        uint256 tokenOracleTimestamp
     ) external payable nonReentrant whenNotPaused {
-        _deposit(amount);
+        _deposit(amount, cotiOracleTimestamp, tokenOracleTimestamp);
     }
 
-    function _deposit(uint256 amount) internal {
+    function _deposit(uint256 amount, uint256 cotiOracleTimestamp, uint256 tokenOracleTimestamp) internal {
         if (!isDepositEnabled) revert DepositDisabled();
         if (amount == 0) revert AmountZero();
+        if (IHasDecimals(address(token)).decimals() != IHasDecimals(address(privateToken)).decimals())
+            revert DecimalsMismatch();
         _checkDepositLimits(amount);
+        _validateOracleTimestamps(cotiOracleTimestamp, tokenOracleTimestamp, tokenSymbol);
 
-        // Step 1: collect flat native COTI fee (refunds excess to sender)
-        _collectNativeFee();
+        // Step 1: compute dynamic fee in COTI
+        uint256 fee = _computeErc20Fee(amount, depositFixedFee, depositPercentageBps, depositMaxFee);
 
-        // Step 2: pull tokens and measure actual received amount (fee-on-transfer safe)
+        // Step 2: collect fee from msg.value (refunds excess to sender)
+        _collectDynamicNativeFee(fee);
+
+        // Step 3: pull full token amount from user
         uint256 balBefore = token.balanceOf(address(this));
         token.safeTransferFrom(msg.sender, address(this), amount);
         uint256 received = token.balanceOf(address(this)) - balBefore;
 
-        // Step 3: deduct bridged-asset deposit fee, get net amount to mint
-        uint256 amountAfterFee = _collectTokenFee(received, depositFeeBasisPoints);
+        // Step 4: mint full private token amount
+        privateToken.mint(msg.sender, received);
 
-        // Step 4: mint private tokens
-        privateToken.mint(msg.sender, amountAfterFee);
-
-        emit Deposit(msg.sender, received, amountAfterFee);
+        emit Deposit(msg.sender, amount, received);
     }
 
     /**
      * @notice Withdraw public ERC20 tokens by burning private tokens
      * @param amount Amount of private tokens to burn
-     * @dev Requires prior approval on the private token. Native COTI fee: send msg.value >= nativeCotiFee; excess refunded best-effort (see deposit).
+     * @param cotiOracleTimestamp The COTI oracle lastUpdated timestamp from estimateWithdrawFee
+     * @param tokenOracleTimestamp The token oracle lastUpdated timestamp from estimateWithdrawFee
+     * @dev Requires prior approval on the private token. Native COTI fee: send msg.value >= computed fee; excess refunded best-effort.
      */
     function withdraw(
-        uint256 amount
+        uint256 amount,
+        uint256 cotiOracleTimestamp,
+        uint256 tokenOracleTimestamp
     ) external payable nonReentrant whenNotPaused {
-        _withdraw(amount);
+        _withdraw(amount, cotiOracleTimestamp, tokenOracleTimestamp);
     }
 
-    function _withdraw(uint256 amount) internal {
+    function _withdraw(uint256 amount, uint256 cotiOracleTimestamp, uint256 tokenOracleTimestamp) internal {
         if (amount == 0) revert AmountZero();
+        if (IHasDecimals(address(token)).decimals() != IHasDecimals(address(privateToken)).decimals())
+            revert DecimalsMismatch();
         _checkWithdrawLimits(amount);
+        _validateOracleTimestamps(cotiOracleTimestamp, tokenOracleTimestamp, tokenSymbol);
 
-        // Step 1: collect flat native COTI fee (refunds excess to sender)
-        _collectNativeFee();
+        // Step 1: compute dynamic fee in COTI
+        uint256 fee = _computeErc20Fee(amount, withdrawFixedFee, withdrawPercentageBps, withdrawMaxFee);
 
-        // Step 2: deduct bridged-asset withdrawal fee, get net amount to release
-        uint256 amountAfterFee = _collectTokenFee(amount, withdrawFeeBasisPoints);
+        // Step 2: collect fee from msg.value (refunds excess to sender)
+        _collectDynamicNativeFee(fee);
 
-        // Step 3: verify bridge has enough liquidity (reserves fee balance)
+        // Step 3: verify bridge has enough liquidity
         uint256 bridgeBalance = token.balanceOf(address(this));
-        if (bridgeBalance < accumulatedFees + amountAfterFee)
+        if (bridgeBalance < amount)
             revert InsufficientBridgeLiquidity();
 
-        // Step 4: pull and burn private tokens
+        // Step 4: pull and burn full private token amount
         privateToken.transferFrom(msg.sender, address(this), amount);
         privateToken.burn(amount);
 
-        // Step 5: release public tokens to user
-        token.safeTransfer(msg.sender, amountAfterFee);
+        // Step 5: release full public token amount to user
+        token.safeTransfer(msg.sender, amount);
 
-        emit Withdraw(msg.sender, amount, amountAfterFee);
+        emit Withdraw(msg.sender, amount, amount);
     }
 
-    /**
-     * @notice Withdraw accumulated fees (ERC20 implementation)
-     * @param to Address to send fees to
-     * @param amount Amount of fees to withdraw
-     * @dev Only the owner can call this function
-     */
-    function withdrawFees(
-        address to,
-        uint256 amount
-    ) external override onlyOperator nonReentrant {
-        if (to == address(0)) revert InvalidAddress();
-        if (amount == 0) revert AmountZero();
-        if (amount > accumulatedFees) revert InsufficientAccumulatedFees();
-
-        accumulatedFees -= amount;
-
-        // Transfer public ERC20 tokens
-        token.safeTransfer(to, amount);
-
-        emit FeesWithdrawn(to, amount);
-    }
 
     /**
-     * @dev Rescue ERC20 tokens sent to the contract (excluding bridge and private tokens)
+     * @dev Rescue ERC20 tokens sent to the contract (excluding private tokens).
+     *      Sends to the predefined rescueRecipient address.
      */
     function rescueERC20(
         address _token,
-        address to,
         uint256 amount
     ) external onlyOwner nonReentrant {
-        if (to == address(0)) revert InvalidAddress();
         if (amount == 0) revert AmountZero();
         
         if ( _token == address(privateToken))
             revert CannotRescueBridgeToken();
 
-        IERC20(_token).safeTransfer(to, amount);
+        IERC20(_token).safeTransfer(rescueRecipient, amount);
 
-        emit ERC20Rescued(_token, to, amount);
+        emit ERC20Rescued(_token, rescueRecipient, amount);
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeUSDCe.sol
+++ b/contracts/privacyBridge/PrivacyBridgeUSDCe.sol
@@ -10,7 +10,7 @@ import "../token/PrivateERC20/tokens/PrivateBridgedUSDC.sol";
  */
 contract PrivacyBridgeUSDCe is PrivacyBridgeERC20 {
 
-    constructor(address _usdc, address _privateUsdc) PrivacyBridgeERC20(_usdc, _privateUsdc, "USDC") {
+    constructor(address _usdc, address _privateUsdc, address _feeRecipient, address _rescueRecipient) PrivacyBridgeERC20(_usdc, _privateUsdc, "USDC", _feeRecipient, _rescueRecipient) {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeUSDCe.sol
+++ b/contracts/privacyBridge/PrivacyBridgeUSDCe.sol
@@ -10,7 +10,7 @@ import "../token/PrivateERC20/tokens/PrivateBridgedUSDC.sol";
  */
 contract PrivacyBridgeUSDCe is PrivacyBridgeERC20 {
 
-    constructor(address _usdc, address _privateUsdc) PrivacyBridgeERC20(_usdc, _privateUsdc) {
+    constructor(address _usdc, address _privateUsdc) PrivacyBridgeERC20(_usdc, _privateUsdc, "USDC") {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeUSDT.sol
+++ b/contracts/privacyBridge/PrivacyBridgeUSDT.sol
@@ -11,7 +11,7 @@ import "../token/PrivateERC20/tokens/PrivateTetherUSD.sol";
 contract PrivacyBridgeUSDT is PrivacyBridgeERC20 {
     
 
-    constructor(address _usdt, address _privateUsdt) PrivacyBridgeERC20(_usdt, _privateUsdt, "USDT") {
+    constructor(address _usdt, address _privateUsdt, address _feeRecipient, address _rescueRecipient) PrivacyBridgeERC20(_usdt, _privateUsdt, "USDT", _feeRecipient, _rescueRecipient) {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeUSDT.sol
+++ b/contracts/privacyBridge/PrivacyBridgeUSDT.sol
@@ -11,7 +11,7 @@ import "../token/PrivateERC20/tokens/PrivateTetherUSD.sol";
 contract PrivacyBridgeUSDT is PrivacyBridgeERC20 {
     
 
-    constructor(address _usdt, address _privateUsdt) PrivacyBridgeERC20(_usdt, _privateUsdt) {
+    constructor(address _usdt, address _privateUsdt) PrivacyBridgeERC20(_usdt, _privateUsdt, "USDT") {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeWADA.sol
+++ b/contracts/privacyBridge/PrivacyBridgeWADA.sol
@@ -11,7 +11,7 @@ import "../token/PrivateERC20/tokens/PrivateWrappedADA.sol";
 contract PrivacyBridgeWADA is PrivacyBridgeERC20 {
     
 
-    constructor(address _wada, address _privateWada) PrivacyBridgeERC20(_wada, _privateWada, "ADA") {
+    constructor(address _wada, address _privateWada, address _feeRecipient, address _rescueRecipient) PrivacyBridgeERC20(_wada, _privateWada, "ADA", _feeRecipient, _rescueRecipient) {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeWADA.sol
+++ b/contracts/privacyBridge/PrivacyBridgeWADA.sol
@@ -11,7 +11,7 @@ import "../token/PrivateERC20/tokens/PrivateWrappedADA.sol";
 contract PrivacyBridgeWADA is PrivacyBridgeERC20 {
     
 
-    constructor(address _wada, address _privateWada) PrivacyBridgeERC20(_wada, _privateWada) {
+    constructor(address _wada, address _privateWada) PrivacyBridgeERC20(_wada, _privateWada, "ADA") {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeWBTC.sol
+++ b/contracts/privacyBridge/PrivacyBridgeWBTC.sol
@@ -11,7 +11,7 @@ import "../token/PrivateERC20/tokens/PrivateWrappedBTC.sol";
 contract PrivacyBridgeWBTC is PrivacyBridgeERC20 {
     
 
-    constructor(address _wbtc, address _privateWbtc) PrivacyBridgeERC20(_wbtc, _privateWbtc, "WBTC") {
+    constructor(address _wbtc, address _privateWbtc, address _feeRecipient, address _rescueRecipient) PrivacyBridgeERC20(_wbtc, _privateWbtc, "WBTC", _feeRecipient, _rescueRecipient) {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeWBTC.sol
+++ b/contracts/privacyBridge/PrivacyBridgeWBTC.sol
@@ -11,7 +11,7 @@ import "../token/PrivateERC20/tokens/PrivateWrappedBTC.sol";
 contract PrivacyBridgeWBTC is PrivacyBridgeERC20 {
     
 
-    constructor(address _wbtc, address _privateWbtc) PrivacyBridgeERC20(_wbtc, _privateWbtc) {
+    constructor(address _wbtc, address _privateWbtc) PrivacyBridgeERC20(_wbtc, _privateWbtc, "WBTC") {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeWETH.sol
+++ b/contracts/privacyBridge/PrivacyBridgeWETH.sol
@@ -11,7 +11,7 @@ import "../token/PrivateERC20/tokens/PrivateWrappedEther.sol";
 contract PrivacyBridgeWETH is PrivacyBridgeERC20 {
     
 
-    constructor(address _weth, address _privateWeth) PrivacyBridgeERC20(_weth, _privateWeth, "ETH") {
+    constructor(address _weth, address _privateWeth, address _feeRecipient, address _rescueRecipient) PrivacyBridgeERC20(_weth, _privateWeth, "ETH", _feeRecipient, _rescueRecipient) {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgeWETH.sol
+++ b/contracts/privacyBridge/PrivacyBridgeWETH.sol
@@ -11,7 +11,7 @@ import "../token/PrivateERC20/tokens/PrivateWrappedEther.sol";
 contract PrivacyBridgeWETH is PrivacyBridgeERC20 {
     
 
-    constructor(address _weth, address _privateWeth) PrivacyBridgeERC20(_weth, _privateWeth) {
+    constructor(address _weth, address _privateWeth) PrivacyBridgeERC20(_weth, _privateWeth, "ETH") {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgegCoti.sol
+++ b/contracts/privacyBridge/PrivacyBridgegCoti.sol
@@ -11,7 +11,7 @@ import "../token/PrivateERC20/tokens/PrivateCOTITreasuryGovernanceToken.sol";
 contract PrivacyBridgegCoti is PrivacyBridgeERC20 {
     
 
-    constructor(address _gCoti, address _privategCoti) PrivacyBridgeERC20(_gCoti, _privategCoti, "GCOTI") {
+    constructor(address _gCoti, address _privategCoti, address _feeRecipient, address _rescueRecipient) PrivacyBridgeERC20(_gCoti, _privategCoti, "GCOTI", _feeRecipient, _rescueRecipient) {
         
     }
 }

--- a/contracts/privacyBridge/PrivacyBridgegCoti.sol
+++ b/contracts/privacyBridge/PrivacyBridgegCoti.sol
@@ -11,7 +11,7 @@ import "../token/PrivateERC20/tokens/PrivateCOTITreasuryGovernanceToken.sol";
 contract PrivacyBridgegCoti is PrivacyBridgeERC20 {
     
 
-    constructor(address _gCoti, address _privategCoti) PrivacyBridgeERC20(_gCoti, _privategCoti) {
+    constructor(address _gCoti, address _privategCoti) PrivacyBridgeERC20(_gCoti, _privategCoti, "GCOTI") {
         
     }
 }


### PR DESCRIPTION
## Summary

Dynamic fee system for Privacy Bridge contracts with oracle timestamp validation and security hardening.

## Fee Formula
```
fee = min(max(fixedFee, percentageOfUsdValue), maxFee)
```
Fees charged in native COTI for all bridges (native and ERC20).

## Files (12)

### New: Oracle
- `contracts/oracle/CotiPriceConsumer.sol` — Band Protocol consumer with min 1h staleness
- `contracts/oracle/ICotiPriceConsumer.sol` — Interface (getPrice, getPriceWithMeta)
- `contracts/oracle/IStdReference.sol` — Band Protocol interface

### Modified: Privacy Bridges
- `contracts/privacyBridge/PrivacyBridge.sol` — Base with dynamic fees, feeRecipient, rescueRecipient, dual timestamp validation
- `contracts/privacyBridge/PrivacyBridgeCotiNative.sol` — Native COTI bridge
- `contracts/privacyBridge/PrivacyBridgeERC20.sol` — ERC20 base bridge
- 6 concrete bridges updated with tokenSymbol constructors

## Key Changes
- **Dual oracle timestamps**: ERC20 deposit/withdraw validate both COTI and token price timestamps
- **feeRecipient**: Predefined address for fee withdrawals (no ad-hoc `to` param)
- **rescueRecipient**: Set at deploy for rescue operations
- **Runtime decimals check**: ERC20 bridges verify decimal parity on every deposit/withdraw
- **Min staleness**: Oracle enforces >= 1 hour, cannot be disabled
- **withdrawFees/withdrawCotiFees**: Restricted to onlyOwner

## Default Fee Parameters
| Parameter | Deposit | Withdraw |
|-----------|---------|----------|
| Fixed (floor) | 10 COTI | 3 COTI |
| Percentage | 0.05% (500/1M) | 0.025% (250/1M) |
| Max (cap) | 3,000 COTI | 1,500 COTI |