### PR TITLE
Security review for PrivacyBridge

### DIFF
--- a/contracts/privacyBridge/PrivacyBridge.sol
+++ b/contracts/privacyBridge/PrivacyBridge.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.19;
 import "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/security/Pausable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/access/AccessControlEnumerable.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "../oracle/ICotiPriceConsumer.sol";
 
@@ -16,7 +16,7 @@ import "../oracle/ICotiPriceConsumer.sol";
  *      (3) Owner operations (limits, fees, pause, withdraw fees, rescue) are centralized; consider timelock/multisig for sensitive actions.
  *      (4) Any new derived bridge must override withdrawFees to perform the actual transfer; base implementation reverts.
  */
-abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessControl {
+abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessControlEnumerable {
     bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
 
     event OperatorAdded(address indexed account, address indexed by);
@@ -180,15 +180,28 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
 
     /**
      * @dev Overrides Ownable's transferOwnership to automatically grant roles to new owner
+     *      and revoke all existing operators to prevent hidden privileged actors.
      */
     function transferOwnership(address newOwner) public override onlyOwner {
         if (newOwner == address(0)) revert InvalidAddress();
-        address oldOwner = owner();
+
+        // Revoke all existing operators before transferring
+        uint256 operatorCount = getRoleMemberCount(OPERATOR_ROLE);
+        for (uint256 i = operatorCount; i > 0; i--) {
+            address op = getRoleMember(OPERATOR_ROLE, i - 1);
+            _revokeRole(OPERATOR_ROLE, op);
+        }
+
+        // Revoke all existing admins
+        uint256 adminCount = getRoleMemberCount(DEFAULT_ADMIN_ROLE);
+        for (uint256 i = adminCount; i > 0; i--) {
+            address admin = getRoleMember(DEFAULT_ADMIN_ROLE, i - 1);
+            _revokeRole(DEFAULT_ADMIN_ROLE, admin);
+        }
+
         super.transferOwnership(newOwner);
         _grantRole(DEFAULT_ADMIN_ROLE, newOwner);
         _grantRole(OPERATOR_ROLE, newOwner);
-        _revokeRole(DEFAULT_ADMIN_ROLE, oldOwner);
-        _revokeRole(OPERATOR_ROLE, oldOwner);
     }
 
     /**

--- a/contracts/privacyBridge/PrivacyBridge.sol
+++ b/contracts/privacyBridge/PrivacyBridge.sol
@@ -257,6 +257,10 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
      * @notice Update deposit and withdrawal limits
      * @dev Ensures min values are less than or equal to max values.
      *      Setting _maxDeposit or _maxWithdraw to 0 effectively disables deposits or withdrawals.
+     *      Note: cross-parameter coherence (e.g. minDeposit after fee >= minWithdraw) cannot be
+     *      validated on-chain because fees are dynamic and depend on the oracle price at transaction
+     *      time, not at the time limits are set. The operator is responsible for ensuring that the
+     *      smallest valid deposit mints at least the smallest valid withdrawal amount.
      * @param _minDeposit New minimum deposit amount
      * @param _maxDeposit New maximum deposit amount
      * @param _minWithdraw New minimum withdrawal amount

--- a/contracts/privacyBridge/PrivacyBridge.sol
+++ b/contracts/privacyBridge/PrivacyBridge.sol
@@ -50,6 +50,10 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     /// @notice Accumulated native COTI fees (used only by ERC20 bridges for per-operation native fee; not used by native bridge)
     uint256 public accumulatedCotiFees;
 
+    /// @notice Outstanding user liability — net amount minted minus net amount released.
+    ///         Represents the total amount owed to users if they all withdraw.
+    uint256 public totalUserLiability;
+
     /// @notice Fee divisor (1,000,000)
     uint256 public constant FEE_DIVISOR = 1000000;
 

--- a/contracts/privacyBridge/PrivacyBridge.sol
+++ b/contracts/privacyBridge/PrivacyBridge.sol
@@ -300,7 +300,9 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     /**
      * @notice Set the native COTI fee
      * @param _fee Amount in native tokens (wei-equivalent)
-     * @dev Used by ERC20 bridges: they require msg.value >= this value and refund excess to the caller (best-effort). Only the operator can call this function.
+     * @dev Used by ERC20 bridges: they require msg.value >= this value and refund excess to the caller (best-effort).
+     *      Only the operator can call this function. Operators are responsible for setting reasonable fees
+     *      and can change fees back whenever needed.
      */
     function setNativeCotiFee(uint256 _fee) external virtual onlyOperator {
         nativeCotiFee = _fee;

--- a/contracts/privacyBridge/PrivacyBridge.sol
+++ b/contracts/privacyBridge/PrivacyBridge.sol
@@ -247,8 +247,8 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     }
 
     /**
-     * @notice Pause the bridge, preventing deposits and withdrawals
-     * @dev Only the owner can call this function
+     * @notice Emergency stop — pause the bridge, preventing all deposits and withdrawals.
+     * @dev Only the owner can call this function.
      */
     function pause() external onlyOwner {
         _pause();

--- a/contracts/privacyBridge/PrivacyBridge.sol
+++ b/contracts/privacyBridge/PrivacyBridge.sol
@@ -109,6 +109,13 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
     error BridgePaused();
     error OracleTimestampMismatch(uint256 expected, uint256 actual);
     error FeeRecipientNotSet();
+    error AddressBlacklisted(address account);
+
+    /// @notice Addresses blocked from depositing or withdrawing
+    mapping(address => bool) public blacklisted;
+
+    event Blacklisted(address indexed account, address indexed by);
+    event UnBlacklisted(address indexed account, address indexed by);
 
     // Limits errors
     error InvalidLimitConfiguration();
@@ -214,6 +221,36 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
      */
     function renounceOwnership() public override onlyOwner {
         revert("renounceOwnership disabled");
+    }
+
+    /**
+     * @notice Add an address to the blacklist, preventing deposits and withdrawals.
+     * @param account The address to blacklist
+     * @dev Only the owner can call this function.
+     */
+    function addToBlacklist(address account) external onlyOwner {
+        if (account == address(0)) revert InvalidAddress();
+        blacklisted[account] = true;
+        emit Blacklisted(account, msg.sender);
+    }
+
+    /**
+     * @notice Remove an address from the blacklist.
+     * @param account The address to remove
+     * @dev Only the owner can call this function.
+     */
+    function removeFromBlacklist(address account) external onlyOwner {
+        if (account == address(0)) revert InvalidAddress();
+        blacklisted[account] = false;
+        emit UnBlacklisted(account, msg.sender);
+    }
+
+    /**
+     * @dev Reverts if the caller is blacklisted.
+     */
+    modifier notBlacklisted() {
+        if (blacklisted[msg.sender]) revert AddressBlacklisted(msg.sender);
+        _;
     }
 
     /**

--- a/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
+++ b/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
@@ -90,6 +90,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge {
 
         accumulatedCotiFees += fee;
 
+        totalUserLiability += netAmount;
         privateCoti.mint(sender, netAmount);
 
         // Emit gross deposit amount and net private tokens minted
@@ -137,6 +138,8 @@ contract PrivacyBridgeCotiNative is PrivacyBridge {
         if (address(this).balance < publicAmount)
             revert InsufficientEthBalance();
 
+        totalUserLiability -= publicAmount;
+
         // Pull and burn private tokens
         IPrivateERC20(address(privateCoti)).transferFrom(
             msg.sender,
@@ -168,6 +171,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge {
 
         accumulatedCotiFees += fee;
 
+        totalUserLiability += netAmount;
         privateCoti.mint(sender, netAmount);
 
         emit Deposit(sender, msg.value, netAmount);
@@ -222,8 +226,8 @@ contract PrivacyBridgeCotiNative is PrivacyBridge {
     function rescueNative(uint256 amount) external onlyOwner nonReentrant {
         if (amount == 0) revert AmountZero();
         if (amount > address(this).balance) revert InsufficientEthBalance();
-        if (address(this).balance < accumulatedFees) revert InsufficientEthBalance();
-        if (amount > address(this).balance - accumulatedFees) revert ExceedsRescueableAmount();
+        if (address(this).balance < accumulatedCotiFees) revert InsufficientEthBalance();
+        if (amount > address(this).balance - accumulatedCotiFees) revert ExceedsRescueableAmount();
 
         (bool success, ) = rescueRecipient.call{value: amount}("");
         if (!success) revert EthTransferFailed();

--- a/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
+++ b/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
@@ -220,6 +220,8 @@ contract PrivacyBridgeCotiNative is PrivacyBridge {
      * @dev Rescue native COTI coins mistakenly sent to the contract.
      *      Only excess over the accumulated fee reserve can be rescued.
      *      Sends to the predefined rescueRecipient address.
+     *      The admin (owner) is fully responsible for invoking this function correctly.
+     *      Misuse can remove bridge liquidity backing user deposits.
      * @param amount Amount of coins to rescue
      * @notice Only the owner can call this function
      */

--- a/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
+++ b/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
@@ -3,13 +3,12 @@ pragma solidity ^0.8.19;
 
 import "./PrivacyBridge.sol";
 import "../token/PrivateERC20/tokens/PrivateCOTI.sol";
-import "../token/PrivateERC20/ITokenReceiver.sol";
 
 /**
  * @title PrivacyBridgeCotiNative
  * @notice Bridge contract for converting between native COTI and privacy-preserving COTI.p tokens
  */
-contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
+contract PrivacyBridgeCotiNative is PrivacyBridge {
     PrivateCOTI public privateCoti;
 
     error ExceedsRescueableAmount();
@@ -105,49 +104,6 @@ contract PrivacyBridgeCotiNative is PrivacyBridge, ITokenReceiver {
      */
     function deposit(uint256 cotiOracleTimestamp, uint256 tokenOracleTimestamp) external payable nonReentrant whenNotPaused {
         _deposit(msg.sender, cotiOracleTimestamp, tokenOracleTimestamp);
-    }
-
-    /**
-     * @notice Handle callback from PrivateCoti.transferAndCall
-     * @dev Called when user transfers tokens to the bridge to withdraw.
-     *      The `data` parameter must be abi-encoded (uint256 cotiOracleTimestamp, uint256 tokenOracleTimestamp).
-     * @param from Address of the sender
-     * @param amount Amount of tokens received
-     * @param data ABI-encoded (uint256, uint256) oracle timestamps from estimateWithdrawFee
-     */
-    function onTokenReceived(
-        address from,
-        uint256 amount,
-        bytes calldata data
-    ) external nonReentrant whenNotPaused returns (bool) {
-        if (msg.sender != address(privateCoti)) revert InvalidAddress();
-        if (amount == 0) revert AmountZero();
-
-        (uint256 cotiOracleTimestamp, uint256 tokenOracleTimestamp) = abi.decode(data, (uint256, uint256));
-        _validateOracleTimestamps(cotiOracleTimestamp, tokenOracleTimestamp, "COTI");
-
-        _checkWithdrawLimits(amount);
-
-        // Compute dynamic withdrawal fee in COTI
-        uint256 fee = _computeCotiFee(amount, withdrawFixedFee, withdrawPercentageBps, withdrawMaxFee);
-        uint256 publicAmount = amount - fee;
-        if (publicAmount == 0) revert AmountZero();
-
-        accumulatedCotiFees += fee;
-
-        if (address(this).balance < publicAmount)
-            revert InsufficientEthBalance();
-
-        // Private tokens are already transferred to this contract by transferAndCall
-        // We just need to burn them.
-        privateCoti.burn(amount);
-
-        (bool success, ) = from.call{value: publicAmount}("");
-        if (!success) revert EthTransferFailed();
-
-        // Emit gross private amount burned and net native COTI sent
-        emit Withdraw(from, amount, publicAmount);
-        return true;
     }
 
     /**

--- a/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
+++ b/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
@@ -103,7 +103,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge {
      * @param tokenOracleTimestamp The token oracle lastUpdated timestamp (same as cotiOracleTimestamp for native bridge)
      * @dev User sends native COTI with the transaction
      */
-    function deposit(uint256 cotiOracleTimestamp, uint256 tokenOracleTimestamp) external payable nonReentrant whenNotPaused {
+    function deposit(uint256 cotiOracleTimestamp, uint256 tokenOracleTimestamp) external payable nonReentrant whenNotPaused notBlacklisted {
         _deposit(msg.sender, cotiOracleTimestamp, tokenOracleTimestamp);
     }
 
@@ -114,7 +114,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge {
      * @param tokenOracleTimestamp The token oracle lastUpdated timestamp (same as cotiOracleTimestamp for native bridge)
      * @dev User must have approved the bridge to spend their private tokens.
      */
-    function withdraw(uint256 amount, uint256 cotiOracleTimestamp, uint256 tokenOracleTimestamp) external nonReentrant whenNotPaused {
+    function withdraw(uint256 amount, uint256 cotiOracleTimestamp, uint256 tokenOracleTimestamp) external nonReentrant whenNotPaused notBlacklisted {
         _withdraw(msg.sender, amount, cotiOracleTimestamp, tokenOracleTimestamp);
     }
 
@@ -182,7 +182,7 @@ contract PrivacyBridgeCotiNative is PrivacyBridge {
      * @dev Mints private tokens at current oracle price without timestamp validation.
      *      For fee-protected deposits, use deposit(cotiOracleTimestamp, tokenOracleTimestamp) instead.
      */
-    receive() external payable nonReentrant whenNotPaused {
+    receive() external payable nonReentrant whenNotPaused notBlacklisted {
         _directDeposit(msg.sender);
     }
 

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -167,6 +167,7 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
         uint256 received = token.balanceOf(address(this)) - balBefore;
 
         // Step 4: mint full private token amount
+        totalUserLiability += received;
         privateToken.mint(msg.sender, received);
 
         emit Deposit(msg.sender, amount, received);
@@ -206,6 +207,7 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
             revert InsufficientBridgeLiquidity();
 
         // Step 4: pull and burn full private token amount
+        totalUserLiability -= amount;
         privateToken.transferFrom(msg.sender, address(this), amount);
         privateToken.burn(amount);
 

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -149,6 +149,11 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
         _deposit(amount, cotiOracleTimestamp, tokenOracleTimestamp);
     }
 
+    /**
+     * @dev Asset support is limited to standard ERC20 tokens only.
+     *      Fee-on-transfer, rebasing, or non-standard ERC20 tokens are not supported
+     *      and may result in incorrect balances or loss of funds.
+     */
     function _deposit(uint256 amount, uint256 cotiOracleTimestamp, uint256 tokenOracleTimestamp) internal {
         if (!isDepositEnabled) revert DepositDisabled();
         if (amount == 0) revert AmountZero();

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -223,6 +223,7 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
      *      Sends to the predefined rescueRecipient address.
      *      The admin (owner) is fully responsible for invoking this function correctly.
      *      Misuse can remove bridge liquidity backing user deposits.
+     *      Note: unless new p.tokens are issued, p.tokens can be reused across multiple bridges.
      */
     function rescueERC20(
         address _token,

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -103,6 +103,8 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
      */
     function _collectDynamicNativeFee(uint256 fee) internal {
         if (msg.value < fee) revert InsufficientCotiFee();
+        // Verify contract balance covers the fee before accounting
+        if (address(this).balance < fee) revert InsufficientEthBalance();
         accumulatedCotiFees += fee;
         if (msg.value > fee) {
             uint256 excess = msg.value - fee;

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -221,6 +221,8 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
     /**
      * @dev Rescue ERC20 tokens sent to the contract (excluding private tokens).
      *      Sends to the predefined rescueRecipient address.
+     *      The admin (owner) is fully responsible for invoking this function correctly.
+     *      Misuse can remove bridge liquidity backing user deposits.
      */
     function rescueERC20(
         address _token,

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -143,7 +143,7 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
         uint256 amount,
         uint256 cotiOracleTimestamp,
         uint256 tokenOracleTimestamp
-    ) external payable nonReentrant whenNotPaused {
+    ) external payable nonReentrant whenNotPaused notBlacklisted {
         _deposit(amount, cotiOracleTimestamp, tokenOracleTimestamp);
     }
 
@@ -184,7 +184,7 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
         uint256 amount,
         uint256 cotiOracleTimestamp,
         uint256 tokenOracleTimestamp
-    ) external payable nonReentrant whenNotPaused {
+    ) external payable nonReentrant whenNotPaused notBlacklisted {
         _withdraw(amount, cotiOracleTimestamp, tokenOracleTimestamp);
     }
 


### PR DESCRIPTION
## SAY-01: Remove onTokenReceived from PrivacyBridgeCotiNative
**File:** `PrivacyBridgeCotiNative.sol`

---
## SAY-02: Document operator responsibility for fee settings
**File:** `PrivacyBridge.sol`

---
## SAY-03: Operators Improvement — AccessControlEnumerable + clean ownership transfer
**File:** `PrivacyBridge.sol`

---
## SAY-04: Track totalUserLiability for collateral enforcement
**Files:** `PrivacyBridge.sol`, `PrivacyBridgeCotiNative.sol`, `PrivacyBridgeERC20.sol`

---
## SAY-05: Document admin responsibility for rescueERC20
**File:** `PrivacyBridgeERC20.sol`

---
## SAY-06: Document admin responsibility for rescueNative
**File:** `PrivacyBridgeCotiNative.sol`

---
## SAY-07: Document pause() as emergency stop
**File:** `PrivacyBridge.sol`

---
## SAY-08: Implement address blacklist for deposit and withdraw
**Files:** `PrivacyBridge.sol`, `PrivacyBridgeCotiNative.sol`, `PrivacyBridgeERC20.sol`

---
## SAY-09: Document p.token reuse across bridges in rescueERC20
**File:** `PrivacyBridgeERC20.sol`

---
## SAY-10: Add balance check before fee accounting in _collectDynamicNativeFee
**File:** `PrivacyBridgeERC20.sol`

---
## SAY-11: Document setLimits cross-parameter coherence limitation

Fees are dynamic (oracle-dependent at tx time), so on-chain validation of minDeposit-after-fee >= minWithdraw is not possible. Added NatSpec comment explaining this and noting operator responsibility.

**File:** `PrivacyBridge.sol`


##  SAY-12: document standard ERC20 token limitation on _deposit

Add NatSpec comment stating asset support is limited to standard ERC20 tokens.

**File:** `PrivacyBridge.ERC20.sol`
