### PR TITLE
Add simulateFee() view function to PrivacyBridge

### DIFF
--- a/contracts/privacyBridge/PrivacyBridge.sol
+++ b/contracts/privacyBridge/PrivacyBridge.sol
@@ -577,6 +577,36 @@ abstract contract PrivacyBridge is ReentrancyGuard, Pausable, Ownable, AccessCon
         emit MaxOracleAgeUpdated(_maxOracleAge, msg.sender);
     }
 
+    /**
+     * @notice Simulate fee calculation with custom parameters.
+     * @dev Reads token and COTI prices from the oracle but allows overriding
+     *      fixedFee, percentageBps, maxFee, and tokenDecimals.
+     *      Use this to preview what fees would look like under different configurations
+     *      without changing on-chain state.
+     * @param amount The token amount to simulate fee for
+     * @param fixedFee The minimum fee floor in COTI wei
+     * @param percentageBps The percentage in basis points (relative to FEE_DIVISOR)
+     * @param maxFee The maximum fee cap in COTI wei
+     * @param tokenSymbol The Band oracle symbol for the token (e.g. "COTI", "ETH", "WBTC")
+     * @param tokenDecimals The decimal precision of the token (e.g. 18, 8, 6)
+     * @return fee The computed fee in native COTI (18 decimals)
+     */
+    function simulateFee(
+        uint256 amount,
+        uint256 fixedFee,
+        uint256 percentageBps,
+        uint256 maxFee,
+        string calldata tokenSymbol,
+        uint8 tokenDecimals
+    ) external view returns (uint256 fee) {
+        uint256 tokenUsdRate = ICotiPriceConsumer(priceOracle).getPrice(tokenSymbol);
+        uint256 cotiUsdRate = ICotiPriceConsumer(priceOracle).getPrice("COTI");
+        uint256 txValueUsd = (amount * tokenUsdRate) / (10 ** tokenDecimals);
+        uint256 percentageFeeUsd = (txValueUsd * percentageBps) / FEE_DIVISOR;
+        uint256 percentageFeeCoti = (percentageFeeUsd * 1e18) / cotiUsdRate;
+        fee = _calculateDynamicFee(percentageFeeCoti, fixedFee, maxFee);
+    }
+
     event CotiFeesWithdrawn(address indexed feeRecipient, uint256 amount);
 
     /**


### PR DESCRIPTION
## Summary

Adds a `simulateFee()` view function to the `PrivacyBridge` base contract that allows operators and frontends to preview fee calculations with custom parameters without changing on-chain state.

### Function Signature

```solidity
function simulateFee(
    uint256 amount,
    uint256 fixedFee,
    uint256 percentageBps,
    uint256 maxFee,
    string calldata tokenSymbol,
    uint8 tokenDecimals
) external view returns (uint256 fee)
```

### How it works
- Reads live `tokenUsdRate` and `cotiUsdRate` from the oracle
- Accepts custom fee parameters (fixedFee, percentageBps, maxFee) as arguments
- Applies the same formula: `min(max(fixedFee, percentageFeeCoti), maxFee)`
- Available on all bridges (native + ERC20) via base contract inheritance

### Use cases
- Frontend fee preview with hypothetical parameters
- Operator testing before committing fee changes
- Backoffice fee simulation tools

## Test Results (COTI Testnet — 15 passing)

```
✔ simulateFee: native COTI — floor dominates for small amount
  simulateFee(100 COTI, default params): 10.0 COTI
✔ simulateFee: native COTI — percentage dominates for large amount
  simulateFee(1M COTI, default params): 500.0 COTI
✔ simulateFee: native COTI — max fee cap applies
  simulateFee(100M COTI, default params): 3000.0 COTI
✔ simulateFee: native COTI — custom high fixed fee
  simulateFee(100 COTI, fixedFee=50): 50.0 COTI
✔ simulateFee: native COTI — custom low max fee
  simulateFee(1M COTI, maxFee=100): 100.0 COTI
✔ simulateFee: native COTI — custom high percentage
  simulateFee(1000 COTI, pct=1%): 10.0 COTI
✔ simulateFee: native COTI — zero percentage means floor always wins
  simulateFee(1M COTI, pct=0%): 10.0 COTI
✔ simulateFee: WETH — percentage dominates (10 WETH)
  simulateFee(10 WETH, default params): 230.0 COTI
✔ simulateFee: WETH — max fee cap (1000 WETH)
  simulateFee(1000 WETH, default params): 3000.0 COTI
✔ simulateFee: WETH — floor dominates for tiny amount (0.001 WETH)
  simulateFee(0.001 WETH, default params): 10.0 COTI
✔ simulateFee: WETH — withdraw params (lower pct, lower cap)
  simulateFee(10 WETH, withdraw params): 115.0 COTI
✔ simulateFee: matches estimateDepositFee on native bridge
  estimateDepositFee: 10.0, simulateFee: 10.0
✔ simulateFee: matches estimateDepositFee on ERC20 bridge
  estimateDepositFee: 230.0, simulateFee: 230.0
✔ simulateFee: matches estimateWithdrawFee on native bridge
  estimateWithdrawFee: 3.0, simulateFee: 3.0
✔ simulateFee: fixedFee equals maxFee means flat fee always
  simulateFee(flat fee=25): 25.0 COTI
```

## Files Changed

- `contracts/privacyBridge/PrivacyBridge.sol` — Added `simulateFee()` view function (30 lines)