### PR TITLE
feat: add computeCotiFee and computeErc20Fee public view functions

### DIFF
--- a/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
+++ b/contracts/privacyBridge/PrivacyBridgeCotiNative.sol
@@ -83,6 +83,25 @@ contract PrivacyBridgeCotiNative is PrivacyBridge {
     }
 
     /**
+     * @notice Simulate fee calculation for native COTI with arbitrary parameters.
+     * @dev Public view — allows frontends/operators to preview fees with custom fee params.
+     *      Reads live COTI oracle price but accepts custom fee configuration.
+     * @param cotiAmount The COTI amount to compute fee for (wei; very large values can revert in fee math)
+     * @param fixedFee The minimum fee floor in COTI wei
+     * @param percentageBps The percentage in basis points (relative to {FEE_DIVISOR})
+     * @param maxFee The maximum fee cap in COTI wei
+     * @return The computed fee in COTI wei
+     */
+    function computeCotiFee(
+        uint256 cotiAmount,
+        uint256 fixedFee,
+        uint256 percentageBps,
+        uint256 maxFee
+    ) external view returns (uint256) {
+        return _computeCotiFee(cotiAmount, fixedFee, percentageBps, maxFee);
+    }
+
+    /**
      * @notice Estimate the deposit fee in COTI for a given COTI amount
      * @param cotiAmount The amount of native COTI to deposit (wei; very large values can revert in fee math)
      * @return fee                The estimated fee in COTI wei

--- a/contracts/privacyBridge/PrivacyBridgeERC20.sol
+++ b/contracts/privacyBridge/PrivacyBridgeERC20.sol
@@ -63,15 +63,27 @@ abstract contract PrivacyBridgeERC20 is PrivacyBridge {
         return _computeErc20FeeAndMeta(tokenAmount, fixedFee, percentageBps, maxFee, tokenSymbol, bridgedTokenDecimals).fee;
     }
 
-    function _computeErc20Fee(
+    /**
+     * @notice Simulate fee calculation for any token symbol and decimals.
+     * @dev Public view — allows frontends/operators to preview fees with arbitrary parameters.
+     *      Reads live oracle prices but accepts custom fee params and token config.
+     * @param tokenAmount The token amount to simulate fee for (raw units; very large values can revert in fee math)
+     * @param fixedFee The minimum fee floor in COTI wei
+     * @param percentageBps The percentage in basis points (relative to {FEE_DIVISOR})
+     * @param maxFee The maximum fee cap in COTI wei
+     * @param _tokenSymbol The Band oracle symbol (e.g. "ETH", "WBTC", "ADA")
+     * @param _tokenDecimals The decimal precision of the token (e.g. 18, 8, 6)
+     * @return The computed fee in native COTI (18 decimals)
+     */
+    function computeErc20Fee(
         uint256 tokenAmount,
         uint256 fixedFee,
         uint256 percentageBps,
         uint256 maxFee,
-        string tokenSymbol,
-        uint8 tokenDecimals
-    ) public view returns (uint256) {
-        return _computeErc20FeeAndMeta(tokenAmount, fixedFee, percentageBps, maxFee, tokenSymbol, tokenDecimals).fee;
+        string calldata _tokenSymbol,
+        uint8 _tokenDecimals
+    ) external view returns (uint256) {
+        return _computeErc20FeeAndMeta(tokenAmount, fixedFee, percentageBps, maxFee, _tokenSymbol, _tokenDecimals).fee;
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds public view functions for fee simulation on each bridge type, allowing frontends and operators to preview fees with custom parameters without executing a transaction.

## Changes (2 files, +36/-5 lines)

**PrivacyBridgeCotiNative.sol** (+19 lines)
- Add `computeCotiFee(cotiAmount, fixedFee, percentageBps, maxFee)` external view
- Delegates to existing internal `_computeCotiFee`

**PrivacyBridgeERC20.sol** (+17/-5 lines)
- Rename `_computeErc20Fee(6 params)` → `computeErc20Fee` (proper public naming)
- `public` → `external` (stricter visibility)
- `string tokenSymbol` → `string calldata _tokenSymbol` (proper data location, no shadowing)
- `uint8 tokenDecimals` → `uint8 _tokenDecimals` (no shadowing)
- Add NatSpec documentation

## Usage

```solidity
// Native bridge — simulate fee for 1000 COTI with custom params
uint256 fee = nativeBridge.computeCotiFee(1000 ether, 10 ether, 500, 3000 ether);

// ERC20 bridge — simulate fee for 10 WETH with custom params
uint256 fee = wethBridge.computeErc20Fee(10 ether, 10 ether, 500, 3000 ether, "ETH", 18);
```

## Testing

- 15 unit tests passing on COTI testnet
- Deployed and verified on testnet