### PR TITLE
AI Audit Updates and Openzeppelin upgrade

### DIFF
--- a/contracts/pod/IInbox.sol
+++ b/contracts/pod/IInbox.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 /// @title IInbox
 /// @notice Cross-chain request/response inbox: send messages to remote chains, execute incoming calls, and query state.

--- a/contracts/pod/IInboxMiner.sol
+++ b/contracts/pod/IInboxMiner.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "./IInbox.sol";
 

--- a/contracts/pod/InboxUser.sol
+++ b/contracts/pod/InboxUser.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "./IInbox.sol";
 

--- a/contracts/pod/InboxUserCotiTestnet.sol
+++ b/contracts/pod/InboxUserCotiTestnet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "./InboxUser.sol";
 import "./PodNetworkConstants.sol";

--- a/contracts/pod/PodNetworkConstants.sol
+++ b/contracts/pod/PodNetworkConstants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 /// @title PodNetworkConstants
 /// @notice Deployment constants used by chain-specific PoD dapp helper contracts.

--- a/contracts/pod/examples/MpcAdder.sol
+++ b/contracts/pod/examples/MpcAdder.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "../../utils/mpc/MpcCore.sol";
 

--- a/contracts/pod/examples/MpcAdderPausable.sol
+++ b/contracts/pod/examples/MpcAdderPausable.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/utils/Pausable.sol";
+
+import "./MpcAdder.sol";
+
+/// @title MpcAdderPausable
+/// @notice Same as {MpcAdder}, but `receiveC` reverts while paused (simulates callback failure until unpaused).
+contract MpcAdderPausable is MpcAdder, Pausable {
+    constructor(address _inbox) MpcAdder(_inbox) {}
+
+    /// @inheritdoc MpcAdder
+    function receiveC(bytes memory data) external override onlyInbox whenNotPaused {
+        _receiveResult(data);
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+}

--- a/contracts/pod/examples/it128/PodAdder128.sol
+++ b/contracts/pod/examples/it128/PodAdder128.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "../../../utils/mpc/MpcCore.sol";
 

--- a/contracts/pod/examples/it256/PodAdder256.sol
+++ b/contracts/pod/examples/it256/PodAdder256.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "../../../utils/mpc/MpcCore.sol";
 

--- a/contracts/pod/fee/IInboxFeeManager.sol
+++ b/contracts/pod/fee/IInboxFeeManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 /// @title IInboxFeeManager
 /// @notice Read-only fee estimation surface exposed by inbox contracts for PoD dapps.

--- a/contracts/pod/manifest.json
+++ b/contracts/pod/manifest.json
@@ -1,7 +1,7 @@
 {
-  "generatedAt": "2026-06-25T12:37:39Z",
+  "generatedAt": "2026-06-28T23:14:27Z",
   "source": "/Users/ith/nk/pod-mpc-lib/contracts",
-  "target": "/Users/ith/nk/coti-contracts/pod",
+  "target": "/Users/ith/nk/coti-contracts/contracts/pod",
   "files": [
     "examples/it128/PodAdder128.sol",
     "examples/it256/PodAdder256.sol",

--- a/contracts/pod/mpc/PodLib.sol
+++ b/contracts/pod/mpc/PodLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "./PodLib64.sol";
 import "./PodLib128.sol";

--- a/contracts/pod/mpc/PodLib128.sol
+++ b/contracts/pod/mpc/PodLib128.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "../../utils/mpc/MpcCore.sol";
 

--- a/contracts/pod/mpc/PodLib256.sol
+++ b/contracts/pod/mpc/PodLib256.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "../../utils/mpc/MpcCore.sol";
 

--- a/contracts/pod/mpc/PodLib64.sol
+++ b/contracts/pod/mpc/PodLib64.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "../../utils/mpc/MpcCore.sol";
 

--- a/contracts/pod/mpc/PodLibBase.sol
+++ b/contracts/pod/mpc/PodLibBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "../../utils/mpc/MpcCore.sol";
 

--- a/contracts/pod/mpc/PodUser.sol
+++ b/contracts/pod/mpc/PodUser.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/contracts/pod/mpc/PodUserFuji.sol
+++ b/contracts/pod/mpc/PodUserFuji.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "./PodUser.sol";
 import "../PodNetworkConstants.sol";

--- a/contracts/pod/mpc/PodUserSepolia.sol
+++ b/contracts/pod/mpc/PodUserSepolia.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "./PodUser.sol";
 import "../PodNetworkConstants.sol";

--- a/contracts/pod/mpc/coti-side/IPodExecutorOps.sol
+++ b/contracts/pod/mpc/coti-side/IPodExecutorOps.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "../../../utils/mpc/MpcCore.sol";
 

--- a/contracts/pod/mpccodec/MpcAbiCodec.sol
+++ b/contracts/pod/mpccodec/MpcAbiCodec.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "../../utils/mpc/MpcCore.sol";
 

--- a/contracts/pod/privacy/IPrivacyPortal.sol
+++ b/contracts/pod/privacy/IPrivacyPortal.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 /// @title IPrivacyPortal
 /// @notice Source-chain portal interface for locking public ERC20 collateral and minting/burning private pTokens.

--- a/contracts/pod/privacy/PrivacyPortal.sol
+++ b/contracts/pod/privacy/PrivacyPortal.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 import "../token/perc20/IPodERC20.sol";
 import "../token/erc7984/IERC7984PortalWrapper.sol";
@@ -23,7 +24,8 @@ interface IPrivacyPortalPauseController {
 /// @title PrivacyPortal
 /// @notice Locks a public ERC20 and mints/burns its PoD private pToken counterpart.
 /// @dev The portal never reads private balances. It only reacts to successful pToken callbacks and records public bridge obligations.
-contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, ReentrancyGuard {
+///      Split deploy-then-initialize is unsafe on clones; use {PrivacyPortalFactory.createPortal} or an equivalent atomic path.
+contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, ReentrancyGuard, Initializable {
     using SafeERC20 for IERC20;
 
     /// @notice Public ERC20 collateral locked by this portal.
@@ -87,8 +89,6 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
     error WithdrawalNotPending(bytes32 withdrawalId, WithdrawalStatus status);
     /// @notice Requested burn cleanup exceeds accumulated debt.
     error BurnDebtTooLow(uint256 debt, uint256 requested);
-    /// @notice Clone was already initialized.
-    error PortalAlreadyInitialized();
     /// @notice Pause controller reports withdrawals are paused.
     error WithdrawalsPaused();
     /// @notice Pause controller reports deposits are paused.
@@ -103,7 +103,9 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
     error NativeTransferFailed();
 
     /// @notice Lock implementation instance by assigning a non-zero owner placeholder.
-    constructor() Ownable(address(1)) {}
+    constructor() Ownable(address(1)) {
+        _disableInitializers();
+    }
 
     /// @notice Accept native funds used only for pToken burn-fee cleanup or accidental recovery.
     /// @dev User-facing deposit and withdrawal fees should be passed as `msg.value`; arbitrary native donations can be swept by the owner.
@@ -115,10 +117,7 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
         address pToken_,
         uint8 decimals_,
         bool nativeWrappedUnderlying_
-    ) external override {
-        if (address(underlyingToken) != address(0)) {
-            revert PortalAlreadyInitialized();
-        }
+    ) external initializer override {
         if (owner_ == address(0)) {
             revert OwnableInvalidOwner(owner_);
         }

--- a/contracts/pod/privacy/PrivacyPortalFactory.sol
+++ b/contracts/pod/privacy/PrivacyPortalFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/proxy/Clones.sol";
@@ -136,6 +136,8 @@ contract PrivacyPortalFactory is Ownable {
     }
 
     /// @notice Deploy a portal and pToken clone for an underlying token and register on the COTI mother ledger.
+    /// @dev Clone deployment and `initialize` run atomically in this transaction. Do not deploy a clone and call
+    ///      `initialize` in a separate transaction—an attacker can front-run initialization and seize the instance.
     /// @param underlying Public ERC20 collateral token.
     /// @param name Source pToken name.
     /// @param symbol Source pToken symbol.

--- a/contracts/pod/token/erc7984/Erc7984Constants.sol
+++ b/contracts/pod/token/erc7984/Erc7984Constants.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 /// @title Erc7984Constants
 /// @notice Shared constants for ERC-7984 explorer compatibility.

--- a/contracts/pod/token/erc7984/Erc7984Pointers.sol
+++ b/contracts/pod/token/erc7984/Erc7984Pointers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "../../../utils/mpc/MpcCore.sol";
 

--- a/contracts/pod/token/erc7984/IERC7984.sol
+++ b/contracts/pod/token/erc7984/IERC7984.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 

--- a/contracts/pod/token/erc7984/IERC7984PortalWrapper.sol
+++ b/contracts/pod/token/erc7984/IERC7984PortalWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 /// @title IERC7984PortalWrapper
 /// @notice Partial ERC-7984 wrapper surface for PrivacyPortal deposit/withdraw explorer visibility.

--- a/contracts/pod/token/erc7984/PodErc7984Mixin.sol
+++ b/contracts/pod/token/erc7984/PodErc7984Mixin.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 import "../../../utils/mpc/MpcCore.sol";

--- a/contracts/pod/token/perc20/IPodERC20.sol
+++ b/contracts/pod/token/perc20/IPodERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "../../../utils/mpc/MpcCore.sol";
 
@@ -101,8 +101,8 @@ interface IPodERC20 {
     function balanceOf(address account) external view returns (ctUint256 memory);
 
     /**
-     * @notice Same as {balanceOf}, plus whether this account is currently locked by an in-flight transfer (or burn).
-     * @dev While `pending` is true, new transfers involving this address as `from` or `to` will revert.
+     * @notice Same as {balanceOf}, plus whether this account is locked by an in-flight outgoing transfer, burn, or mint (recipient).
+     * @dev While `pending` is true, new transfers or burns from this account (or mints to it) will revert.
      */
     function balanceOfWithStatus(address account) external view returns (ctUint256 memory, bool pending);
 
@@ -111,8 +111,8 @@ interface IPodERC20 {
     /**
      * @notice Starts an encrypted transfer of `value` from the caller to `to`.
      * @return requestId Inbox request id; completion is asynchronous via {Transfer} or {TransferFailed}.
-     * @dev **Gotcha:** reverts if either the sender or `to` already has a pending transfer. **Gotcha:** concurrent approvals use a
-     *      separate pending map and do not block transfers unless your deployment couples them elsewhere.
+     * @dev **Gotcha:** reverts if the sender already has a pending transfer or burn. Incoming transfers do not lock the recipient.
+     *      **Gotcha:** concurrent approvals use a separate pending map and do not block transfers unless your deployment couples them elsewhere.
      * @param callbackFeeLocalWei Caller-estimated wei slice for the callback leg; total payment is `msg.value`.
      */
     function transfer(address to, itUint256 calldata value, uint256 callbackFeeLocalWei) external payable returns (bytes32 requestId);

--- a/contracts/pod/token/perc20/PodERC20.sol
+++ b/contracts/pod/token/perc20/PodERC20.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
-import "../../../utils/mpc/MpcCore.sol";
 import "../../InboxUser.sol";
 import "../../fee/IInboxFeeManager.sol";
 import "../../mpccodec/MpcAbiCodec.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
 import "./IPodERC20.sol";
 import "./cotiside/IPodErc20CotiSide.sol";
 import "../erc7984/PodErc7984Mixin.sol";
@@ -13,7 +13,8 @@ import "../erc7984/PodErc7984Mixin.sol";
 /// @title PodERC20
 /// @notice PoD-side private ERC-20: ciphertext cache and inbox-mediated async moves; COTI holds authoritative garbled state via {IPodErc20CotiSide}.
 /// @dev Callbacks only from `inbox` when the remote peer matches (`cotiChainId`, `cotiSideContract`). Public-amount methods expose amounts in calldata and logs; use encrypted `itUint256` entry points for privacy-sensitive flows.
-contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
+///      {_sendPodTwoWay} is `nonReentrant` so a compromised inbox/oracle cannot re-enter before pending locks are written.
+contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTransient {
     using MpcAbiCodec for MpcAbiCodec.MpcMethodCallContext;
 
     // --- State variables ---
@@ -43,7 +44,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
     bytes32 private constant PERMIT_DOMAIN_VERSION_HASH = keccak256("1");
     mapping(address => ctUint256) private _balances;
     mapping(address => mapping(address => IPodERC20.Allowance)) private _allowance;
-    /// @dev One in-flight transfer or burn per address (used as both sender and receiver lock for transfers).
+    /// @dev One in-flight transfer or burn per sender; mints lock the recipient until callback.
     mapping(address => bytes32) private _pendingTransferRequestIds;
     mapping(address => mapping(address => bytes32)) private _pendingApprovalRequestIds;
     /// @dev Optional `transferAndCall` payload keyed by inbox `sourceRequestId`, cleared after callback.
@@ -68,7 +69,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
 
     // --- Errors ---
 
-    /// @notice A transfer/burn lock already exists for one of the affected accounts.
+    /// @notice A transfer or burn lock already exists for the sender (or mint lock for the recipient).
     error TransferAlreadyPending(address from, address to, bytes32 requestId);
     /// @notice An approval lock already exists for the owner/spender pair.
     error ApprovalAlreadyPending(address owner, address spender, bytes32 requestId);
@@ -294,7 +295,9 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
             }
         }
         if (to != address(0)) {
-            _pendingTransferRequestIds[to] = bytes32(0);
+            if (from == address(0)) {
+                _pendingTransferRequestIds[to] = bytes32(0);
+            }
             if (balanceNonces[to] < nonce) {
                 _balances[to] = newBalanceTo;
                 balanceNonces[to] = nonce;
@@ -362,7 +365,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
 
     /**
      * @notice Clears pending transfer state and records `failedRequests` for this `sourceRequestId`.
-     * @dev **Gotcha:** when both `from` and `to` were locked, both are cleared; `TransferFailed` carries decoded addresses.
+     * @dev Transfers and burns lock only `from`; mints lock only `to` (`from == address(0)` in the error payload).
      */
     function transferError(bytes memory data) external onlyInbox {
         (uint256 remoteChainId, address remoteContract) = inbox.inboxMsgSender();
@@ -375,8 +378,9 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
         failedRequests[sourceRequestId] = errorMsg;
         if (from != address(0)) {
             _pendingTransferRequestIds[from] = bytes32(0);
+        } else if (to != address(0)) {
+            _pendingTransferRequestIds[to] = bytes32(0);
         }
-        _pendingTransferRequestIds[to] = bytes32(0);
         emit TransferFailed(from, to, errorMsg);
     }
 
@@ -505,7 +509,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
         IInbox.MpcMethodCall memory mpcMethodCall,
         bytes4 callbackSelector_,
         bytes4 errorSelector_
-    ) internal returns (bytes32) {
+    ) internal nonReentrant returns (bytes32) {
         require(callbackFeeLocalWei >= 1, "PodERC20: callback fee min");
         require(callbackFeeLocalWei <= totalValueWei, "PodERC20: callback exceeds total");
         require(address(this).balance >= totalValueWei, "PodERC20: inbox fee");
@@ -570,8 +574,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
     }
 
     /**
-     * @dev **Gotcha:** `TransferAlreadyPending` carries `_pendingTransferRequestIds[from]` even when `to` was the party that
-     *      was actually pending—inspect both sides off-chain when debugging reverts.
+     * @dev Transfers lock only `from`; receivers accept concurrent in-flight credits (nonce ordering on callback).
      */
     function _transfer(
         bytes4 remoteTransferSelector,
@@ -581,7 +584,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
         uint256 totalValueWei,
         uint256 callbackFeeLocalWei
     ) internal returns (bytes32 requestId) {
-        if (_pendingTransferRequestIds[from] != bytes32(0) || _pendingTransferRequestIds[to] != bytes32(0)) {
+        if (_pendingTransferRequestIds[from] != bytes32(0)) {
             revert TransferAlreadyPending(from, to, _pendingTransferRequestIds[from]);
         }
 
@@ -600,7 +603,6 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
         );
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
         _pendingTransferRequestIds[from] = requestId;
-        _pendingTransferRequestIds[to] = requestId;
         emit TransferRequestSubmitted(msg.sender, to, requestId);
     }
 
@@ -613,7 +615,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
         uint256 totalValueWei,
         uint256 callbackFeeLocalWei
     ) internal returns (bytes32 requestId) {
-        if (_pendingTransferRequestIds[from] != bytes32(0) || _pendingTransferRequestIds[to] != bytes32(0)) {
+        if (_pendingTransferRequestIds[from] != bytes32(0)) {
             revert TransferAlreadyPending(from, to, _pendingTransferRequestIds[from]);
         }
 
@@ -633,7 +635,6 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
         );
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
         _pendingTransferRequestIds[from] = requestId;
-        _pendingTransferRequestIds[to] = requestId;
         emit TransferRequestSubmitted(from, to, requestId);
     }
 
@@ -728,7 +729,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
         uint256 totalValueWei,
         uint256 callbackFeeLocalWei
     ) internal returns (bytes32 requestId) {
-        if (_pendingTransferRequestIds[from] != bytes32(0) || _pendingTransferRequestIds[to] != bytes32(0)) {
+        if (_pendingTransferRequestIds[from] != bytes32(0)) {
             revert TransferAlreadyPending(from, to, _pendingTransferRequestIds[from]);
         }
 
@@ -747,7 +748,6 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
         );
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
         _pendingTransferRequestIds[from] = requestId;
-        _pendingTransferRequestIds[to] = requestId;
         emit TransferRequestSubmitted(msg.sender, to, requestId);
     }
 
@@ -760,7 +760,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
         uint256 totalValueWei,
         uint256 callbackFeeLocalWei
     ) internal returns (bytes32 requestId) {
-        if (_pendingTransferRequestIds[from] != bytes32(0) || _pendingTransferRequestIds[to] != bytes32(0)) {
+        if (_pendingTransferRequestIds[from] != bytes32(0)) {
             revert TransferAlreadyPending(from, to, _pendingTransferRequestIds[from]);
         }
 
@@ -780,7 +780,6 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
         );
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
         _pendingTransferRequestIds[from] = requestId;
-        _pendingTransferRequestIds[to] = requestId;
         emit TransferRequestSubmitted(from, to, requestId);
     }
 
@@ -793,7 +792,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
         uint256 totalValueWei,
         uint256 callbackFeeLocalWei
     ) internal returns (bytes32 requestId) {
-        if (_pendingTransferRequestIds[from] != bytes32(0) || _pendingTransferRequestIds[to] != bytes32(0)) {
+        if (_pendingTransferRequestIds[from] != bytes32(0)) {
             revert TransferAlreadyPending(from, to, _pendingTransferRequestIds[from]);
         }
         _consumePublicTransferPermit(from, spender, to, amount, permit);
@@ -813,7 +812,6 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin {
         );
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
         _pendingTransferRequestIds[from] = requestId;
-        _pendingTransferRequestIds[to] = requestId;
         emit TransferRequestSubmitted(from, to, requestId);
     }
 

--- a/contracts/pod/token/perc20/PodErc20Mintable.sol
+++ b/contracts/pod/token/perc20/PodErc20Mintable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "./PodERC20.sol";
 

--- a/contracts/pod/token/perc20/PodErc20MintableInitializable.sol
+++ b/contracts/pod/token/perc20/PodErc20MintableInitializable.sol
@@ -1,13 +1,18 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
+import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 import "./PodErc20Mintable.sol";
 
 /// @title PodErc20MintableInitializable
-/// @notice Clone-friendly {PodErc20Mintable}; the implementation constructor only locks the implementation instance.
-contract PodErc20MintableInitializable is PodErc20Mintable {
+/// @notice Clone-friendly {PodErc20Mintable}; the implementation constructor locks the implementation instance.
+/// @dev Split deploy-then-initialize is unsafe: an attacker can front-run `initialize` on an uninitialized clone.
+///      Use {PrivacyPortalFactory.createPortal} or another single-transaction clone+init path.
+contract PodErc20MintableInitializable is PodErc20Mintable, Initializable {
     /// @notice Lock the implementation instance with placeholder values.
-    constructor() PodErc20Mintable(address(1), 1, address(1), address(1), "IMPLEMENTATION", "IMPL") {}
+    constructor() PodErc20Mintable(address(1), 1, address(1), address(1), "IMPLEMENTATION", "IMPL") {
+        _disableInitializers();
+    }
 
     /// @notice Initialize a mintable source-chain pToken clone.
     /// @param _minter Address allowed to mint.
@@ -25,7 +30,7 @@ contract PodErc20MintableInitializable is PodErc20Mintable {
         string memory _name,
         string memory _symbol,
         uint8 _decimals
-    ) external {
+    ) external initializer {
         _initializePodErc20Mintable(_minter, _cotiChainId, _inbox, _cotiSideContract, _name, _symbol, _decimals);
     }
 }

--- a/contracts/pod/token/perc20/cotiside/IPodErc20CotiSide.sol
+++ b/contracts/pod/token/perc20/cotiside/IPodErc20CotiSide.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "../../../../utils/mpc/MpcCore.sol";
 
@@ -69,12 +69,12 @@ interface IPodErc20CotiSide {
      * @notice Sets garbled allowance and `respond`s with owner- and spender-specific ciphertext of the same allowance amount.
      * @dev On invalid addresses the implementation should `raise` rather than revert if you need PoD `approveError` symmetry.
      */
-    function approve(address owner, address spender, gtUint256 value) external;
+    function approve(address tokenOwner, address spender, gtUint256 value) external;
 
     /**
      * @notice Plain-amount variant of {approve}; COTI garbles via `MpcCore.setPublic256`.
      */
-    function approvePublic(address owner, address spender, uint256 value) external;
+    function approvePublic(address tokenOwner, address spender, uint256 value) external;
 
     /**
      * @notice Subtracts `value` from `from` and responds with a burn-shaped tuple (`to == 0`, zero ciphertexts for receiver side).

--- a/contracts/pod/token/perc20/cotiside/PodErc20CotiMother.sol
+++ b/contracts/pod/token/perc20/cotiside/PodErc20CotiMother.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 import "../../../../utils/mpc/MpcCore.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
@@ -75,13 +75,13 @@ contract PodErc20CotiMother is IPodErc20CotiSide, InboxUser, Ownable {
     );
     event ApprovalCompleted(
         bytes32 indexed tokenId,
-        address indexed owner,
+        address indexed tokenOwner,
         address indexed spender,
         bool amountIsPublic,
         uint256 publicAmount
     );
     event TransferFailureRaised(bytes32 indexed tokenId, address indexed from, address indexed to, bytes reason);
-    event ApprovalFailureRaised(bytes32 indexed tokenId, address indexed owner, address indexed spender, bytes reason);
+    event ApprovalFailureRaised(bytes32 indexed tokenId, address indexed tokenOwner, address indexed spender, bytes reason);
     event SyncBalancesFailureRaised(bytes32 indexed tokenId, bytes reason);
 
     // --- Errors ---
@@ -267,20 +267,20 @@ contract PodErc20CotiMother is IPodErc20CotiSide, InboxUser, Ownable {
 
     /// @inheritdoc IPodErc20CotiSide
     function approve(
-        address owner,
+        address tokenOwner,
         address spender,
         gtUint256 value
     ) external override onlyRegisteredPTokenMessage {
-        _approveInternal(_activeTokenId(), owner, spender, value, false, 0);
+        _approveInternal(_activeTokenId(), tokenOwner, spender, value, false, 0);
     }
 
     /// @inheritdoc IPodErc20CotiSide
     function approvePublic(
-        address owner,
+        address tokenOwner,
         address spender,
         uint256 value
     ) external override onlyRegisteredPTokenMessage {
-        _approveInternal(_activeTokenId(), owner, spender, MpcCore.setPublic256(value), true, value);
+        _approveInternal(_activeTokenId(), tokenOwner, spender, MpcCore.setPublic256(value), true, value);
     }
 
     /// @inheritdoc IPodErc20CotiSide
@@ -426,8 +426,8 @@ contract PodErc20CotiMother is IPodErc20CotiSide, InboxUser, Ownable {
         _tokenNonce[id] = transferNonce + 1;
     }
 
-    function _readGarbledAllowance(bytes32 id, address owner, address spender) private returns (gtUint256) {
-        ctUint256 memory ct = _allowanceCiphertext[id][owner][spender];
+    function _readGarbledAllowance(bytes32 id, address tokenOwner, address spender) private returns (gtUint256) {
+        ctUint256 memory ct = _allowanceCiphertext[id][tokenOwner][spender];
         if (_isEmptyCtUint256(ct)) {
             return MpcCore.onBoard(_ciphertextPlainZero());
         }
@@ -451,23 +451,23 @@ contract PodErc20CotiMother is IPodErc20CotiSide, InboxUser, Ownable {
 
     function _approveInternal(
         bytes32 id,
-        address owner,
+        address tokenOwner,
         address spender,
         gtUint256 garbledAllowance,
         bool amountIsPublic,
         uint256 publicAmount
     ) private {
-        if (owner == address(0) || spender == address(0)) {
-            _sendApproveFailureToPod(id, owner, spender, bytes("PodErc20CotiMother: zero owner or spender"));
+        if (tokenOwner == address(0) || spender == address(0)) {
+            _sendApproveFailureToPod(id, tokenOwner, spender, bytes("PodErc20CotiMother: zero owner or spender"));
             return;
         }
 
-        _allowanceCiphertext[id][owner][spender] = MpcCore.offBoard(garbledAllowance);
+        _allowanceCiphertext[id][tokenOwner][spender] = MpcCore.offBoard(garbledAllowance);
 
-        ctUint256 memory ciphertextForOwner = MpcCore.offBoardToUser(garbledAllowance, owner);
+        ctUint256 memory ciphertextForOwner = MpcCore.offBoardToUser(garbledAllowance, tokenOwner);
         ctUint256 memory ciphertextForSpender = MpcCore.offBoardToUser(garbledAllowance, spender);
-        inbox.respond(abi.encode(owner, ciphertextForOwner, spender, ciphertextForSpender));
-        emit ApprovalCompleted(id, owner, spender, amountIsPublic, publicAmount);
+        inbox.respond(abi.encode(tokenOwner, ciphertextForOwner, spender, ciphertextForSpender));
+        emit ApprovalCompleted(id, tokenOwner, spender, amountIsPublic, publicAmount);
     }
 
     function _mintInternal(
@@ -508,9 +508,9 @@ contract PodErc20CotiMother is IPodErc20CotiSide, InboxUser, Ownable {
         inbox.raise(abi.encode(from, to, reason));
     }
 
-    function _sendApproveFailureToPod(bytes32 id, address owner, address spender, bytes memory reason) private {
-        emit ApprovalFailureRaised(id, owner, spender, reason);
-        inbox.raise(abi.encode(owner, spender, reason));
+    function _sendApproveFailureToPod(bytes32 id, address tokenOwner, address spender, bytes memory reason) private {
+        emit ApprovalFailureRaised(id, tokenOwner, spender, reason);
+        inbox.raise(abi.encode(tokenOwner, spender, reason));
     }
 
     function _sendSyncFailureToPod(bytes32 id, bytes memory reason) private {

--- a/contracts/pod/utils/IWrappedNative.sol
+++ b/contracts/pod/utils/IWrappedNative.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.19;
+pragma solidity ^0.8.20;
 
 /// @notice Minimal WETH9 / WAVAX interface for wrap-on-deposit and unwrap-on-withdraw.
 interface IWrappedNative {


### PR DESCRIPTION
## Summary

Audit-driven hardening for PoD pTokens, Privacy Portal clones, and inbox gas efficiency. Addresses findings **M-01**, **M-02**, and **L-02**, plus consistency cleanup across the contract tree.

### Security

**M-01 — Asymmetric pending-transfer locks (`PodERC20`)**
- Transfers and burns lock only **`from`**; mints lock only **`to`**
- Recipients can receive concurrent in-flight credits (callback nonce ordering still applies)
- `transferCallback` / `transferError` clear the recipient lock only on mint paths (`from == address(0)`)
- NatSpec and `IPodERC20` updated; test added in `test/tokens/pod-token.ts`

**M-02 — Clone init frontrun (`PodErc20MintableInitializable`, `PrivacyPortal`, `PrivacyPortalFactory`)**
- Clone implementations use OpenZeppelin **`Initializable`** + **`_disableInitializers()`** in constructors
- `initialize()` gated with the **`initializer`** modifier
- Factory NatSpec documents that **clone + init must be atomic** in one transaction; split deploy-then-init is unsafe
- Removed redundant `PortalAlreadyInitialized` error (OZ handles double-init)

**L-02 — Reentrancy during inbox send (`PodERC20`)**
- **`ReentrancyGuardTransient`** on **`_sendPodTwoWay`** (`nonReentrant`)
- Blocks re-entry through any outbox path (transfer, approve, burn, mint, sync) before pending locks are written
- Uses EIP-1153 transient storage (~300 gas) instead of a double SSTORE sentinel (~5k gas extra)

**Naming — `PodErc20CotiMother`**
- Renamed allowance `owner` parameters to **`tokenOwner`** to avoid shadowing **`Ownable.owner()`**
- Updated `IPodErc20CotiSide`, events, and internal helpers

### Gas / inbox

**G-01 — Compact inbox events**
- `MessageSent` / `MessageReceived` emit selector, hash, and length metadata instead of full `MpcMethodCall` payloads
- Full payload remains in storage and view functions
- `test/InboxCompactEvents.ts`, updated `scripts/test-helpers/inbox-abi.ts`

**Inbox hot-path optimizations**
- `InboxBase`: cached context in `respond`/`raise`, `getRequests` improvements, raw-call fast path in `_safeEncodeMethodCall`
- `InboxMiner`: removed redundant storage reload, unchecked loop increments
- `InboxFeeManager`: single `getPricesUSD()` call, cached fee configs
- Gas matrix script and audit doc: `scripts/inbox-gas-matrix.ts`, `ai_audit/v3/inbox-gas-efficiency.md`

### Consistency / tooling

- All Solidity contracts: **`pragma solidity ^0.8.20`**
- **`@openzeppelin/contracts` ^5.4.0**
- **`hardhat.config.ts`**: `evmVersion` **`paris` → `cancun`** (required for `ReentrancyGuardTransient` / EIP-1153)
- **`scripts/copy-pod-contracts.sh`**: copies dApp-facing contracts to `coti-contracts` layout with MPC import remapping

## Test plan

- [ ] `npx hardhat compile` (Cancun / transient storage)
- [ ] `npm run test:inbox-events` — compact event shape
- [ ] `npm run test:inbox-gas` — gas matrix baseline
- [ ] `npm run test:inbox` / `npm run test:inbox-fee` — inbox regressions
- [ ] `npm run test:pod-token` — asymmetric transfer locks (`POD_TOKEN_SYSTEM_TESTS=1`, COTI env)
- [ ] `npm run test:pp-system` — portal factory atomic deploy+init
- [ ] Deploy clone implementations and verify `_disableInitializers()` blocks direct `initialize()` on implementation addresses
- [ ] Confirm target chains support **Cancun** (EIP-1153) before mainnet deploy

## Deployment notes

- Redeploy **pToken** and **portal implementation** contracts (initializer pattern changed)
- Existing clones are unaffected; new clones must continue to use factory **`createPortal`** (atomic init)
- Compiler target is now **Cancun** — verify Sepolia / Fuji / COTI testnet support before production deploy