### PR TITLE
feat: add PrivateNight token and PrivacyBridgeNight bridge

### DIFF
--- a/contracts/privacyBridge/PrivacyBridgeNight.sol
+++ b/contracts/privacyBridge/PrivacyBridgeNight.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "./PrivacyBridgeERC20.sol";
+import "../token/PrivateERC20/tokens/PrivateNight.sol";
+
+/**
+ * @title PrivacyBridgeNight
+ * @notice Bridge contract for converting between NIGHT and privacy-preserving p.NIGHT tokens
+ */
+contract PrivacyBridgeNight is PrivacyBridgeERC20 {
+
+
+    constructor(
+        address _night,
+        address _privateNight,
+        address _feeRecipient,
+        address _rescueRecipient,
+        address _priceOracle
+    ) PrivacyBridgeERC20(_night, _privateNight, "NIGHT", _feeRecipient, _rescueRecipient, _priceOracle) {
+
+    }
+}

--- a/contracts/token/PrivateERC20/tokens/PrivateNight.sol
+++ b/contracts/token/PrivateERC20/tokens/PrivateNight.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "../PrivateERC20.sol";
+
+/**
+ * @title PrivateNight
+ * @notice Privacy-preserving NIGHT token (p.NIGHT) using COTI's Multi-Party Computation (MPC)
+ * @dev Extends PayableToken for role-based minting/burning and bridge operations
+ */
+contract PrivateNight is PrivateERC20 {
+    constructor() PrivateERC20("Private Night", "p.NIGHT") {}
+
+    function decimals() public view virtual override returns (uint8) {
+        return 6;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PrivateNight` (p.NIGHT), a privacy-preserving MPC token mirroring `PrivateWrappedADA`, 6 decimals to match the public NIGHT token.
- Add `PrivacyBridgeNight`, bridging NIGHT <-> p.NIGHT, mirroring `PrivacyBridgeWADA`.

## Test plan
- [x] Compiles successfully
- [x] Deployed and verified end-to-end on COTI testnet:
  - NIGHT: `0x918084eee42832f08b868Ea64Bba2d41A5F360c6`
  - p.NIGHT: `0xfb3A2F7ca2416e7BE312feA60a647f880B840957`
  - PrivacyBridgeNight: `0x025b0E54ae5fac3BF3ca6eDe7bd62fa684c25D29`
  - MINTER_ROLE granted to the bridge on p.NIGHT
  - Confirmed oracle has a live NIGHT/USD feed for fee calculations