### PR TITLE
Create parity PP and PrivacyBridge + handle system errors inbox

### DIFF
--- a/contracts/pod/IInbox.sol
+++ b/contracts/pod/IInbox.sol
@@ -7,6 +7,26 @@ pragma solidity ^0.8.20;
 interface IInbox {
     // --- Types ---
 
+    /// @notice Classification of the current inbox execution when delivering an error callback.
+    /// @dev Used by source `errorSelector` handlers: ignore {NotErrorContext}; branch on {SystemError} vs {Exception}.
+    ///      Call only from `errorSelector` entrypoints — linked success `respond` legs can also report {Exception}.
+    enum InboxErrorType {
+        /// @notice No active message, or the active call is not a linked error/system delivery.
+        NotErrorContext,
+        /// @notice Inbox system-error return leg (`originalSender` is {SYSTEM_SENDER}).
+        SystemError,
+        /// @notice Linked return leg for a request that registered an `errorSelector` (app `raise`).
+        Exception
+    }
+
+    /// @notice Minimal payload for Inbox system-error callbacks (`errorSelector(bytes data)`).
+    /// @dev App `raise` payloads are dApp-defined; decode them only when {inboxErrorType()} is {Exception}.
+    ///      System encode failure uses `errorCode = 2`. Attribution is via {SYSTEM_SENDER} on the return leg.
+    struct ErrorData {
+        uint64 errorCode;
+        bytes message;
+    }
+
     /// @notice Encoded method call and optional MPC ABI metadata.
     struct MpcMethodCall {
         /// @notice Function selector to re-encode with MPC GTs; zero means `data` is raw calldata.
@@ -37,7 +57,10 @@ interface IInbox {
         uint64 timestamp;
         /// @notice Callback selector used for two-way success responses.
         bytes4 callbackSelector;
-        /// @notice Error selector used for failed execution responses.
+        /// @notice Error selector invoked with `errorSelector(bytes data)` for app `raise` **or** Inbox system errors.
+        /// @dev Same delivery path. Distinguish with {inboxErrorType()}: {SystemError} ({ErrorData} payload,
+        ///      {SYSTEM_SENDER}) vs {Exception} (dApp-defined `raise` bytes). System errors are not eligible for
+        ///      `retryFailedRequest`. Auth: `onlyInbox` + non-zero {inboxSourceRequestId}.
         bytes4 errorSelector;
         /// @notice True when a success response is expected.
         bool isTwoWay;
@@ -162,8 +185,10 @@ interface IInbox {
     function getIncomingRequest(bytes32 requestId) external view returns (Request memory);
 
     /// @notice Remote chain ID and contract for the currently executing incoming message.
+    /// @dev For system-error return legs, `contractAddress` is {SYSTEM_SENDER}. Success callbacks still
+    ///      come from the real remote peer; error callbacks should not require peer equality.
     /// @return chainId Remote chain ID.
-    /// @return contractAddress Remote caller contract.
+    /// @return contractAddress Remote caller contract (or {SYSTEM_SENDER} for Inbox system errors).
     function inboxMsgSender() external view returns (uint256 chainId, address contractAddress);
 
     /// @notice Request ID for the currently executing incoming message.
@@ -171,8 +196,16 @@ interface IInbox {
     function inboxRequestId() external view returns (bytes32);
 
     /// @notice Source request ID linked from the current incoming message (if any).
+    /// @dev Non-zero only for reply/error legs created by {respond}, {raise}, or system-error delivery.
+    ///      Public {sendOneWayMessage}/{sendTwoWayMessage} always use `sourceRequestId = 0`.
     /// @return sourceRequestId Linked request ID.
     function inboxSourceRequestId() external view returns (bytes32);
+
+    /// @notice Whether the current execution is delivering a system error, an app `raise`, or neither.
+    /// @dev Safe to call outside an active message (returns {InboxErrorType.NotErrorContext}). Prefer this over
+    ///      requiring `inboxMsgSender()` peer equality in error handlers.
+    /// @return errorType {InboxErrorType} for the active context.
+    function inboxErrorType() external view returns (InboxErrorType errorType);
 
     // --- External: pure ---
 

--- a/contracts/pod/privacy/IPrivacyPortal.sol
+++ b/contracts/pod/privacy/IPrivacyPortal.sol
@@ -58,12 +58,12 @@ interface IPrivacyPortal {
     }
 
     /// @notice Initialize a clone portal.
-    /// @param owner Owner / DEFAULT_ADMIN / initial OPERATOR.
+    /// @param owner Ownable portal owner (limits, pause/unpause, blacklist, batch burn, rescue).
     /// @param underlyingToken Public ERC20 locked and released by this portal (WETH/WAVAX when native-wrapped).
     /// @param pToken PoD pToken minted and burned for the underlying token.
     /// @param decimals Token decimals exposed for UI compatibility.
     /// @param nativeWrappedUnderlying When true, {depositNative} accepts native coin (wraps in-contract); withdraw releases wrapped underlying ERC20.
-    /// @param factory PrivacyPortalFactory (or compatible) for fees, blacklist, and rescue recipient.
+    /// @param factory PrivacyPortalFactory (fees, pause, blacklist, rescue, operators).
     function initialize(
         address owner,
         address underlyingToken,
@@ -165,10 +165,8 @@ interface IPrivacyPortal {
         payable
         returns (bytes32 burnRequestId);
 
-    /// @notice Update or disable the external pause controller for deposits and withdrawals.
-    function setPauseController(address pauseController) external;
-
     /// @notice Set per-portal deposit fee override; zero packed config clears override.
+    /// @dev Caller must hold factory {OPERATOR_ROLE}.
     function setDepositFee(uint256 fixedFee, uint256 percentageBps, uint256 maxFee) external;
 
     /// @notice Set per-portal withdraw fee override.

--- a/contracts/pod/privacy/IPrivacyPortal.sol
+++ b/contracts/pod/privacy/IPrivacyPortal.sol
@@ -14,7 +14,33 @@ interface IPrivacyPortal {
         /// @notice pToken transfer to the portal has been requested but not yet released.
         TransferPending,
         /// @notice Underlying collateral was released to the recipient.
-        Released
+        Released,
+        /// @notice Async pToken transfer failed; withdrawal abandoned without releasing collateral.
+        Failed
+    }
+
+    /// @notice Deposit escrow lifecycle for collateral locked pending async mint.
+    enum DepositEscrowStatus {
+        /// @notice No escrow exists for the mint request id.
+        None,
+        /// @notice Underlying is locked awaiting mint success or failure.
+        Pending,
+        /// @notice Mint request hit an Inbox system error; collateral is eligible for refund.
+        Failed,
+        /// @notice Underlying was returned to the depositor after a failed mint.
+        Refunded
+    }
+
+    /// @notice Escrow of public collateral locked for an async pToken mint.
+    struct DepositEscrow {
+        /// @notice User who deposited the underlying (refund recipient).
+        address user;
+        /// @notice Intended pToken mint recipient.
+        address recipient;
+        /// @notice Locked underlying amount.
+        uint256 amount;
+        /// @notice Escrow lifecycle status.
+        DepositEscrowStatus status;
     }
 
     /// @notice Withdrawal request state stored by withdrawal id.
@@ -32,18 +58,23 @@ interface IPrivacyPortal {
     }
 
     /// @notice Initialize a clone portal.
-    /// @param owner Owner for admin functions.
+    /// @param owner Owner / DEFAULT_ADMIN / initial OPERATOR.
     /// @param underlyingToken Public ERC20 locked and released by this portal (WETH/WAVAX when native-wrapped).
     /// @param pToken PoD pToken minted and burned for the underlying token.
     /// @param decimals Token decimals exposed for UI compatibility.
     /// @param nativeWrappedUnderlying When true, {depositNative} accepts native coin (wraps in-contract); withdraw releases wrapped underlying ERC20.
+    /// @param factory PrivacyPortalFactory (or compatible) for fees, blacklist, and rescue recipient.
     function initialize(
         address owner,
         address underlyingToken,
         address pToken,
         uint8 decimals,
-        bool nativeWrappedUnderlying
+        bool nativeWrappedUnderlying,
+        address factory
     ) external;
+
+    /// @notice Factory that created / binds this portal.
+    function factory() external view returns (address);
 
     /// @notice Whether this portal accepts native coin on deposit via {depositNative}.
     function nativeWrappedUnderlying() external view returns (bool);
@@ -110,6 +141,24 @@ interface IPrivacyPortal {
     /// @notice Manually release a pending withdrawal after its pToken transfer request is marked successful.
     function triggerWithdrawalRelease(bytes32 withdrawalId) external;
 
+    /// @notice Refund underlying collateral after a mint Inbox system error
+    ///         (`pToken.requests(requestId).status == SystemFailed`).
+    /// @dev App `raise` / `Failed` is not refundable (mint should not raise). Portal protocol fee is kept.
+    ///      Only the original depositor may claim.
+    /// @param requestId Mint request id returned by {deposit} / {depositNative} / {wrap}.
+    function refundFailedDeposit(bytes32 requestId) external;
+
+    /// @notice Mark a pending withdrawal as Failed after its pToken transfer request fails.
+    /// @dev Does not release underlying; user retains pTokens. Portal protocol fee is kept.
+    /// @param withdrawalId Portal withdrawal id from {requestWithdrawWithPermit}.
+    function cancelFailedWithdrawal(bytes32 withdrawalId) external;
+
+    /// @notice Escrow state for a deposit mint request id.
+    function depositEscrows(bytes32 requestId)
+        external
+        view
+        returns (address user, address recipient, uint256 amount, DepositEscrowStatus status);
+
     /// @notice Owner batch-burn for pTokens accumulated from completed withdrawals.
     function burnAccumulatedPTokens(uint256 amount, uint256 burnCallbackFee)
         external
@@ -155,8 +204,11 @@ interface IPrivacyPortal {
     /// @notice Sweep accumulated portal protocol fees to the factory fee recipient.
     function withdrawPortalFees(uint256 amount) external;
 
-    /// @notice Sweep accidental native-token balance to `recipient`.
-    function sweepNative(address payable recipient, uint256 amount) external;
+    /// @notice Rescue native to the factory {rescueRecipient} while paused.
+    function rescueNative(uint256 amount) external;
+
+    /// @notice Rescue ERC20 to the factory {rescueRecipient} while paused (not the paired pToken).
+    function rescueERC20(address token, uint256 amount) external;
 
     /// @notice Estimate deposit fees for UI quoting.
     function estimateDepositFees(uint256 amount)

--- a/contracts/pod/privacy/IPrivacyPortal.sol
+++ b/contracts/pod/privacy/IPrivacyPortal.sol
@@ -142,7 +142,7 @@ interface IPrivacyPortal {
     /// @notice Refund underlying collateral after a mint Inbox system error
     ///         (`pToken.requests(requestId).status == SystemFailed`).
     /// @dev App `raise` / `Failed` is not refundable (mint should not raise). Portal protocol fee is kept.
-    ///      Only the original depositor may claim.
+    ///      Permissionless: anyone may call; underlying is always sent to the original depositor.
     /// @param requestId Mint request id returned by {deposit} / {depositNative} / {wrap}.
     function refundFailedDeposit(bytes32 requestId) external;
 

--- a/contracts/pod/privacy/IPrivacyPortal.sol
+++ b/contracts/pod/privacy/IPrivacyPortal.sol
@@ -58,14 +58,12 @@ interface IPrivacyPortal {
     }
 
     /// @notice Initialize a clone portal.
-    /// @param owner Ownable portal owner (limits, pause/unpause, blacklist, batch burn, rescue).
     /// @param underlyingToken Public ERC20 locked and released by this portal (WETH/WAVAX when native-wrapped).
     /// @param pToken PoD pToken minted and burned for the underlying token.
     /// @param decimals Token decimals exposed for UI compatibility.
     /// @param nativeWrappedUnderlying When true, {depositNative} accepts native coin (wraps in-contract); withdraw releases wrapped underlying ERC20.
-    /// @param factory PrivacyPortalFactory (fees, pause, blacklist, rescue, operators).
+    /// @param factory PrivacyPortalFactory (admin, fees, pause, blacklist, rescue, operators).
     function initialize(
-        address owner,
         address underlyingToken,
         address pToken,
         uint8 decimals,
@@ -82,7 +80,7 @@ interface IPrivacyPortal {
     /// @notice Accumulated portal protocol fees awaiting sweep.
     function accumulatedPortalFees() external view returns (uint256);
 
-    /// @notice pToken amount held in portal custody pending owner batch burn.
+    /// @notice pToken amount held in portal custody pending factory-admin batch burn.
     function pendingBurnAmount() external view returns (uint256);
 
     /// @notice Lock public ERC20 and request a private pToken mint.

--- a/contracts/pod/privacy/IPrivacyPortalFactory.sol
+++ b/contracts/pod/privacy/IPrivacyPortalFactory.sol
@@ -34,6 +34,9 @@ interface IPrivacyPortalFactory is IPrivacyPortalPauseController, IPrivacyPortal
     /// @notice Recipient of swept portal protocol fees.
     function feeRecipient() external view returns (address);
 
+    /// @notice Catastrophe rescue destination used by portals from this factory.
+    function rescueRecipient() external view returns (address);
+
     /// @notice Wrapped native token on this chain (WETH/WAVAX) used for portal fee gas pricing.
     function nativeToken() external view returns (address);
 

--- a/contracts/pod/privacy/IPrivacyPortalFactory.sol
+++ b/contracts/pod/privacy/IPrivacyPortalFactory.sol
@@ -38,7 +38,7 @@ interface IPrivacyPortalFactory is IPrivacyPortalPauseController, IPrivacyPortal
     /// @notice Whether `account` holds factory {OPERATOR_ROLE} (portal fee / soft-deposit controls).
     function isOperator(address account) external view returns (bool);
 
-    /// @notice Recipient of swept portal protocol fees.
+    /// @notice Recipient of swept portal protocol fees (fixed at factory deploy).
     function feeRecipient() external view returns (address);
 
     /// @notice Catastrophe rescue destination used by portals from this factory.

--- a/contracts/pod/privacy/IPrivacyPortalFactory.sol
+++ b/contracts/pod/privacy/IPrivacyPortalFactory.sol
@@ -29,8 +29,11 @@ interface IPrivacyPortalBlacklistController {
 /// @title IPrivacyPortalFactory
 /// @notice Factory surface used by portal clones for pause control, blacklist, fees, and operators.
 interface IPrivacyPortalFactory is IPrivacyPortalPauseController, IPrivacyPortalBlacklistController {
-    /// @notice Primary factory admin ({DEFAULT_ADMIN_ROLE} holder with lowest enumeration index).
+    /// @notice Primary factory admin for tooling (`Ownable.owner()`-shaped).
     function owner() external view returns (address);
+
+    /// @notice Whether `account` holds factory {DEFAULT_ADMIN_ROLE} (portal admin / pause / rescue / limits).
+    function isAdmin(address account) external view returns (bool);
 
     /// @notice Whether `account` holds factory {OPERATOR_ROLE} (portal fee / soft-deposit controls).
     function isOperator(address account) external view returns (bool);

--- a/contracts/pod/privacy/IPrivacyPortalFactory.sol
+++ b/contracts/pod/privacy/IPrivacyPortalFactory.sol
@@ -10,7 +10,8 @@ struct PortalFeeConfig {
     uint256 maxFee;
 }
 
-/// @notice Pause flags exposed by the factory to portal clones.
+/// @notice Pause flags exposed by the factory (and readable by portal clones).
+/// @dev Both views reflect the same {Pausable.paused} state after factory {pause}/{unpause}.
 interface IPrivacyPortalPauseController {
     /// @notice Whether new withdrawal requests should revert.
     function withdrawalsPaused() external view returns (bool);
@@ -26,10 +27,13 @@ interface IPrivacyPortalBlacklistController {
 }
 
 /// @title IPrivacyPortalFactory
-/// @notice Factory surface used by portal clones for pause control, blacklist, and fee configuration.
+/// @notice Factory surface used by portal clones for pause control, blacklist, fees, and operators.
 interface IPrivacyPortalFactory is IPrivacyPortalPauseController, IPrivacyPortalBlacklistController {
     /// @notice Primary factory admin ({DEFAULT_ADMIN_ROLE} holder with lowest enumeration index).
     function owner() external view returns (address);
+
+    /// @notice Whether `account` holds factory {OPERATOR_ROLE} (portal fee / soft-deposit controls).
+    function isOperator(address account) external view returns (bool);
 
     /// @notice Recipient of swept portal protocol fees.
     function feeRecipient() external view returns (address);

--- a/contracts/pod/privacy/PrivacyPortal.sol
+++ b/contracts/pod/privacy/PrivacyPortal.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
 import "@openzeppelin/contracts/utils/Pausable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
@@ -21,7 +20,8 @@ import "./PrivacyPortalFeeLib.sol";
 /// @notice Locks a public ERC20 and mints/burns its PoD private pToken counterpart.
 /// @dev The portal never reads private balances. It only reacts to successful pToken callbacks and records public bridge obligations.
 ///      Split deploy-then-initialize is unsafe on clones; use {PrivacyPortalFactory.createPortal} or an equivalent atomic path.
-contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, AccessControlEnumerable, Pausable, ReentrancyGuard, Initializable {
+///      Operator privileges ({OPERATOR_ROLE}) live on {factory} only — not on the portal.
+contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Pausable, ReentrancyGuard, Initializable {
     using SafeERC20 for IERC20;
     using PrivacyPortalFeeLib for bytes32;
 
@@ -29,23 +29,15 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Access
     IERC20 public underlyingToken;
     /// @notice Private pToken minted and burned against the underlying collateral.
     IPodERC20 public pToken;
-    /// @notice Factory that created this portal (fees, blacklist, rescue recipient, defaults).
+    /// @notice Factory that created this portal (fees, pause, blacklist, rescue, operators).
     address public factory;
-    /// @notice Optional pause controller for deposits and withdrawals; zero disables pause checks.
-    address public pauseController;
     /// @notice Token decimals mirrored from the underlying/pToken pair.
     uint8 public decimals;
     /// @notice When true, {depositNative} wraps native coin; withdrawals release wrapped underlying ERC20.
     bool public nativeWrappedUnderlying;
 
-    /// @notice Operator role for fee / soft-deposit controls (mirrors Privacy Bridge).
-    bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
-    /// @notice Soft deposit switch (operator); independent of pause / factory pause.
+    /// @notice Soft deposit switch (factory operator); independent of pause / factory pause.
     bool public isDepositEnabled = true;
-    /// @notice Per-portal deposit pause override (ORs with factory pause).
-    bool public depositsPausedLocal;
-    /// @notice Per-portal withdrawal pause override (ORs with factory pause).
-    bool public withdrawalsPausedLocal;
     /// @notice Per-portal blacklist (ORs with factory blacklist).
     mapping(address => bool) public blacklisted;
 
@@ -127,8 +119,6 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Access
     event PortalFeeOverrideUpdated(bool indexed isDeposit, bytes32 packedConfig);
     /// @notice Per-portal fee override cleared.
     event PortalFeeOverrideCleared(bool indexed isDeposit);
-    /// @notice Pause controller was changed.
-    event PauseControllerUpdated(address indexed pauseController);
     /// @notice Factory binding set at initialize (immutable thereafter).
     event FactorySet(address indexed factory);
     /// @notice Per-portal deposit/withdraw limits changed.
@@ -144,12 +134,6 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Access
     event ERC20Rescued(address indexed token, address indexed rescueRecipient, uint256 amount);
     /// @notice Soft deposit-enabled flag changed.
     event DepositEnabledUpdated(bool enabled);
-    /// @notice Local deposit/withdraw pause flags changed.
-    event LocalPauseUpdated(bool depositsPaused, bool withdrawalsPaused);
-    /// @notice Operator added.
-    event OperatorAdded(address indexed account, address indexed by);
-    /// @notice Operator removed.
-    event OperatorRemoved(address indexed account, address indexed by);
     /// @notice Address added to the portal blacklist.
     event Blacklisted(address indexed account, address indexed by);
     /// @notice Address removed from the portal blacklist.
@@ -179,8 +163,6 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Access
     error WithdrawalsPaused();
     /// @notice Pause controller reports deposits are paused.
     error DepositsPaused();
-    /// @notice Configured pause controller did not return a valid pause flag.
-    error PauseControllerFault();
     /// @notice pToken transfer request has not succeeded yet.
     error PTokenTransferNotSuccessful(bytes32 requestId, IPodERC20.RequestStatus status);
     /// @notice Deposit escrow is missing or not eligible for the requested action.
@@ -209,6 +191,8 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Access
     error InvalidLimitConfiguration();
     /// @notice Soft deposit switch is off.
     error DepositDisabled();
+    /// @notice Caller is not a factory {OPERATOR_ROLE} holder.
+    error OnlyFactoryOperator(address caller);
     /// @notice Cannot rescue the paired pToken.
     error CannotRescuePToken();
     /// @notice Native transfer failed.
@@ -237,8 +221,6 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Access
             revert InvalidAddress();
         }
         _transferOwnership(owner_);
-        _grantRole(DEFAULT_ADMIN_ROLE, owner_);
-        _grantRole(OPERATOR_ROLE, owner_);
         underlyingToken = IERC20(underlyingToken_);
         pToken = IPodERC20(pToken_);
         decimals = decimals_;
@@ -249,65 +231,24 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Access
         minDepositAmount = 1;
         minWithdrawAmount = 1;
         factory = factory_;
-        pauseController = factory_;
         emit FactorySet(factory_);
-        emit PauseControllerUpdated(factory_);
     }
 
-    /// @inheritdoc AccessControlEnumerable
-    function supportsInterface(bytes4 interfaceId)
-        public
-        view
-        override(AccessControlEnumerable)
-        returns (bool)
-    {
-        return super.supportsInterface(interfaceId);
-    }
-
-    /// @notice Register an operator (fee / soft-deposit controls).
-    function addOperator(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (account == address(0)) {
-            revert InvalidAddress();
-        }
-        _grantRole(OPERATOR_ROLE, account);
-        emit OperatorAdded(account, msg.sender);
-    }
-
-    /// @notice Revoke an operator.
-    function removeOperator(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (account == address(0)) {
-            revert InvalidAddress();
-        }
-        _revokeRole(OPERATOR_ROLE, account);
-        emit OperatorRemoved(account, msg.sender);
-    }
-
-    /// @notice Whether `account` has {OPERATOR_ROLE}.
-    function isOperator(address account) external view returns (bool) {
-        return hasRole(OPERATOR_ROLE, account);
-    }
-
-    /// @notice Owner hard-pause (enables rescue). Also blocks user deposit/withdraw entry points.
+    /// @notice Owner hard-pause for this portal instance (enables rescue). Checked before factory pause.
     function pause() external onlyOwner {
         _pause();
     }
 
-    /// @notice Owner unpause.
+    /// @notice Owner unpause for this portal instance.
     function unpause() external onlyOwner {
         _unpause();
     }
 
-    /// @notice Soft deposit enable/disable (operator); does not enable rescue.
-    function setIsDepositEnabled(bool enabled) external onlyRole(OPERATOR_ROLE) {
+    /// @notice Soft deposit enable/disable (factory operator); does not enable rescue.
+    function setIsDepositEnabled(bool enabled) external {
+        _checkFactoryOperator();
         isDepositEnabled = enabled;
         emit DepositEnabledUpdated(enabled);
-    }
-
-    /// @notice Per-portal pause overrides (OR with factory pause flags).
-    function setLocalPause(bool depositsPaused, bool withdrawalsPaused) external onlyOwner {
-        depositsPausedLocal = depositsPaused;
-        withdrawalsPausedLocal = withdrawalsPaused;
-        emit LocalPauseUpdated(depositsPaused, withdrawalsPaused);
     }
 
     /// @notice Add an address to this portal's blacklist.
@@ -349,34 +290,32 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Access
         emit LimitsUpdated(minDeposit, maxDeposit, minWithdraw, maxWithdraw);
     }
 
-    /// @notice Update the external pause controller checked before deposits and withdrawal requests.
-    function setPauseController(address pauseController_) external onlyOwner {
-        pauseController = pauseController_;
-        emit PauseControllerUpdated(pauseController_);
-    }
-
     /// @inheritdoc IPrivacyPortal
-    function setDepositFee(uint256 fixedFee, uint256 percentageBps, uint256 maxFee) external onlyRole(OPERATOR_ROLE) {
+    function setDepositFee(uint256 fixedFee, uint256 percentageBps, uint256 maxFee) external {
+        _checkFactoryOperator();
         bytes32 packed = PrivacyPortalFeeLib.packFeeConfig(fixedFee, percentageBps, maxFee);
         depositFeeOverridePacked = packed;
         emit PortalFeeOverrideUpdated(true, packed);
     }
 
     /// @inheritdoc IPrivacyPortal
-    function setWithdrawFee(uint256 fixedFee, uint256 percentageBps, uint256 maxFee) external onlyRole(OPERATOR_ROLE) {
+    function setWithdrawFee(uint256 fixedFee, uint256 percentageBps, uint256 maxFee) external {
+        _checkFactoryOperator();
         bytes32 packed = PrivacyPortalFeeLib.packFeeConfig(fixedFee, percentageBps, maxFee);
         withdrawFeeOverridePacked = packed;
         emit PortalFeeOverrideUpdated(false, packed);
     }
 
     /// @inheritdoc IPrivacyPortal
-    function clearDepositFeeOverride() external onlyRole(OPERATOR_ROLE) {
+    function clearDepositFeeOverride() external {
+        _checkFactoryOperator();
         depositFeeOverridePacked = bytes32(0);
         emit PortalFeeOverrideCleared(true);
     }
 
     /// @inheritdoc IPrivacyPortal
-    function clearWithdrawFeeOverride() external onlyRole(OPERATOR_ROLE) {
+    function clearWithdrawFeeOverride() external {
+        _checkFactoryOperator();
         withdrawFeeOverridePacked = bytes32(0);
         emit PortalFeeOverrideCleared(false);
     }
@@ -889,24 +828,25 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Access
         return IPrivacyPortalFactory(factory_);
     }
 
-    function _checkWithdrawalsNotPaused() private view {
-        if (paused()) {
-            revert WithdrawalsPaused();
+    function _checkFactoryOperator() private view {
+        if (!_factory().isOperator(msg.sender)) {
+            revert OnlyFactoryOperator(msg.sender);
         }
-        if (withdrawalsPausedLocal || _pauseFlag(IPrivacyPortalPauseController.withdrawalsPaused.selector)) {
+    }
+
+    function _checkWithdrawalsNotPaused() private view {
+        // Local instance pause first, then factory-wide pause.
+        if (paused() || _factory().withdrawalsPaused()) {
             revert WithdrawalsPaused();
         }
     }
 
     function _checkDepositsNotPaused() private view {
-        if (paused()) {
+        if (paused() || _factory().depositsPaused()) {
             revert DepositsPaused();
         }
         if (!isDepositEnabled) {
             revert DepositDisabled();
-        }
-        if (depositsPausedLocal || _pauseFlag(IPrivacyPortalPauseController.depositsPaused.selector)) {
-            revert DepositsPaused();
         }
     }
 
@@ -932,20 +872,5 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Access
         if (amount > maxWithdrawAmount) {
             revert WithdrawExceedsMaximum();
         }
-    }
-
-    function _pauseFlag(bytes4 selector) private view returns (bool) {
-        address controller = pauseController;
-        if (controller == address(0)) {
-            return false;
-        }
-        if (controller.code.length == 0) {
-            return false;
-        }
-        (bool success, bytes memory data) = controller.staticcall(abi.encodeWithSelector(selector));
-        if (!success || data.length < 32) {
-            revert PauseControllerFault();
-        }
-        return abi.decode(data, (bool));
     }
 }

--- a/contracts/pod/privacy/PrivacyPortal.sol
+++ b/contracts/pod/privacy/PrivacyPortal.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Pausable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
@@ -20,8 +19,8 @@ import "./PrivacyPortalFeeLib.sol";
 /// @notice Locks a public ERC20 and mints/burns its PoD private pToken counterpart.
 /// @dev The portal never reads private balances. It only reacts to successful pToken callbacks and records public bridge obligations.
 ///      Split deploy-then-initialize is unsafe on clones; use {PrivacyPortalFactory.createPortal} or an equivalent atomic path.
-///      Operator privileges ({OPERATOR_ROLE}) live on {factory} only — not on the portal.
-contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Pausable, ReentrancyGuard, Initializable {
+///      Admin and operator privileges live on {factory} only — portals have no local Ownable.
+contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Pausable, ReentrancyGuard, Initializable {
     using SafeERC20 for IERC20;
     using PrivacyPortalFeeLib for bytes32;
 
@@ -193,13 +192,15 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Pausab
     error DepositDisabled();
     /// @notice Caller is not a factory {OPERATOR_ROLE} holder.
     error OnlyFactoryOperator(address caller);
+    /// @notice Caller is not a factory {DEFAULT_ADMIN_ROLE} holder.
+    error OnlyFactoryAdmin(address caller);
     /// @notice Cannot rescue the paired pToken.
     error CannotRescuePToken();
     /// @notice Native transfer failed.
     error EthTransferFailed();
 
-    /// @notice Lock implementation instance by assigning a non-zero owner placeholder.
-    constructor() Ownable(address(1)) {
+    /// @notice Lock implementation so it cannot be initialized.
+    constructor() {
         _disableInitializers();
     }
 
@@ -207,20 +208,15 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Pausab
     receive() external payable {}
 
     function initialize(
-        address owner_,
         address underlyingToken_,
         address pToken_,
         uint8 decimals_,
         bool nativeWrappedUnderlying_,
         address factory_
     ) external initializer override {
-        if (owner_ == address(0)) {
-            revert OwnableInvalidOwner(owner_);
-        }
         if (underlyingToken_ == address(0) || pToken_ == address(0) || factory_ == address(0)) {
             revert InvalidAddress();
         }
-        _transferOwnership(owner_);
         underlyingToken = IERC20(underlyingToken_);
         pToken = IPodERC20(pToken_);
         decimals = decimals_;
@@ -234,25 +230,24 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Pausab
         emit FactorySet(factory_);
     }
 
-    /// @notice Owner hard-pause for this portal instance (enables rescue). Checked before factory pause.
-    function pause() external onlyOwner {
+    /// @notice Factory-admin hard-pause for this portal instance (enables rescue). Checked before factory pause.
+    function pause() external onlyFactoryAdmin {
         _pause();
     }
 
-    /// @notice Owner unpause for this portal instance.
-    function unpause() external onlyOwner {
+    /// @notice Factory-admin unpause for this portal instance.
+    function unpause() external onlyFactoryAdmin {
         _unpause();
     }
 
     /// @notice Soft deposit enable/disable (factory operator); does not enable rescue.
-    function setIsDepositEnabled(bool enabled) external {
-        _checkFactoryOperator();
+    function setIsDepositEnabled(bool enabled) external onlyFactoryOperator {
         isDepositEnabled = enabled;
         emit DepositEnabledUpdated(enabled);
     }
 
     /// @notice Add an address to this portal's blacklist.
-    function addToBlacklist(address account) external onlyOwner {
+    function addToBlacklist(address account) external onlyFactoryAdmin {
         if (account == address(0)) {
             revert InvalidAddress();
         }
@@ -261,7 +256,7 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Pausab
     }
 
     /// @notice Remove an address from this portal's blacklist.
-    function removeFromBlacklist(address account) external onlyOwner {
+    function removeFromBlacklist(address account) external onlyFactoryAdmin {
         if (account == address(0)) {
             revert InvalidAddress();
         }
@@ -276,7 +271,7 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Pausab
         uint256 maxDeposit,
         uint256 minWithdraw,
         uint256 maxWithdraw
-    ) external onlyOwner {
+    ) external onlyFactoryAdmin {
         if (minDeposit > maxDeposit) {
             revert InvalidLimitConfiguration();
         }
@@ -291,31 +286,27 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Pausab
     }
 
     /// @inheritdoc IPrivacyPortal
-    function setDepositFee(uint256 fixedFee, uint256 percentageBps, uint256 maxFee) external {
-        _checkFactoryOperator();
+    function setDepositFee(uint256 fixedFee, uint256 percentageBps, uint256 maxFee) external onlyFactoryOperator {
         bytes32 packed = PrivacyPortalFeeLib.packFeeConfig(fixedFee, percentageBps, maxFee);
         depositFeeOverridePacked = packed;
         emit PortalFeeOverrideUpdated(true, packed);
     }
 
     /// @inheritdoc IPrivacyPortal
-    function setWithdrawFee(uint256 fixedFee, uint256 percentageBps, uint256 maxFee) external {
-        _checkFactoryOperator();
+    function setWithdrawFee(uint256 fixedFee, uint256 percentageBps, uint256 maxFee) external onlyFactoryOperator {
         bytes32 packed = PrivacyPortalFeeLib.packFeeConfig(fixedFee, percentageBps, maxFee);
         withdrawFeeOverridePacked = packed;
         emit PortalFeeOverrideUpdated(false, packed);
     }
 
     /// @inheritdoc IPrivacyPortal
-    function clearDepositFeeOverride() external {
-        _checkFactoryOperator();
+    function clearDepositFeeOverride() external onlyFactoryOperator {
         depositFeeOverridePacked = bytes32(0);
         emit PortalFeeOverrideCleared(true);
     }
 
     /// @inheritdoc IPrivacyPortal
-    function clearWithdrawFeeOverride() external {
-        _checkFactoryOperator();
+    function clearWithdrawFeeOverride() external onlyFactoryOperator {
         withdrawFeeOverridePacked = bytes32(0);
         emit PortalFeeOverrideCleared(false);
     }
@@ -559,7 +550,7 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Pausab
     function burnAccumulatedPTokens(uint256 amount, uint256 burnCallbackFee)
         external
         payable
-        onlyOwner
+        onlyFactoryAdmin
         nonReentrant
         returns (bytes32 burnRequestId)
     {
@@ -579,7 +570,7 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Pausab
     }
 
     /// @inheritdoc IPrivacyPortal
-    function withdrawPortalFees(uint256 amount) external onlyOwner nonReentrant {
+    function withdrawPortalFees(uint256 amount) external onlyFactoryAdmin nonReentrant {
         if (amount == 0) {
             revert InvalidAmount();
         }
@@ -600,7 +591,7 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Pausab
     }
 
     /// @notice Rescue native balance to the factory rescue recipient while paused (catastrophe path).
-    function rescueNative(uint256 amount) external onlyOwner nonReentrant whenPaused {
+    function rescueNative(uint256 amount) external onlyFactoryAdmin nonReentrant whenPaused {
         if (amount == 0) {
             revert InvalidAmount();
         }
@@ -621,7 +612,7 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Pausab
     }
 
     /// @notice Rescue ERC20 balance to the factory rescue recipient while paused. Cannot rescue the paired pToken.
-    function rescueERC20(address token, uint256 amount) external onlyOwner nonReentrant whenPaused {
+    function rescueERC20(address token, uint256 amount) external onlyFactoryAdmin nonReentrant whenPaused {
         if (token == address(0) || amount == 0) {
             revert InvalidAmount();
         }
@@ -828,10 +819,18 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Pausab
         return IPrivacyPortalFactory(factory_);
     }
 
-    function _checkFactoryOperator() private view {
+    modifier onlyFactoryOperator() {
         if (!_factory().isOperator(msg.sender)) {
             revert OnlyFactoryOperator(msg.sender);
         }
+        _;
+    }
+
+    modifier onlyFactoryAdmin() {
+        if (!_factory().isAdmin(msg.sender)) {
+            revert OnlyFactoryAdmin(msg.sender);
+        }
+        _;
     }
 
     function _checkWithdrawalsNotPaused() private view {

--- a/contracts/pod/privacy/PrivacyPortal.sol
+++ b/contracts/pod/privacy/PrivacyPortal.sol
@@ -166,8 +166,6 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Pausable, Reent
     error PTokenTransferNotSuccessful(bytes32 requestId, IPodERC20.RequestStatus status);
     /// @notice Deposit escrow is missing or not eligible for the requested action.
     error DepositEscrowInvalid(bytes32 requestId, DepositEscrowStatus status);
-    /// @notice Caller is not the original depositor for this escrow.
-    error OnlyDepositUser(address caller, address user);
     /// @notice Mint request is not {IPodERC20.RequestStatus.SystemFailed}, so escrow cannot be refunded.
     error DepositMintNotFailed(bytes32 requestId, IPodERC20.RequestStatus status);
     /// @notice Transfer request is not Failed/SystemFailed, so withdrawal cannot be cancelled.
@@ -504,11 +502,9 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Pausable, Reent
         if (status != DepositEscrowStatus.Pending && status != DepositEscrowStatus.Failed) {
             revert DepositEscrowInvalid(requestId, status);
         }
-        if (msg.sender != escrow.user) {
-            revert OnlyDepositUser(msg.sender, escrow.user);
-        }
         IPodERC20.RequestStatus mintStatus = pToken.requests(requestId).status;
         // Mint should not `raise`; only Inbox system errors are refundable.
+        // Permissionless: anyone may trigger; underlying always returns to {escrow.user}.
         if (mintStatus != IPodERC20.RequestStatus.SystemFailed) {
             revert DepositMintNotFailed(requestId, mintStatus);
         }

--- a/contracts/pod/privacy/PrivacyPortal.sol
+++ b/contracts/pod/privacy/PrivacyPortal.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
@@ -19,7 +21,7 @@ import "./PrivacyPortalFeeLib.sol";
 /// @notice Locks a public ERC20 and mints/burns its PoD private pToken counterpart.
 /// @dev The portal never reads private balances. It only reacts to successful pToken callbacks and records public bridge obligations.
 ///      Split deploy-then-initialize is unsafe on clones; use {PrivacyPortalFactory.createPortal} or an equivalent atomic path.
-contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, ReentrancyGuard, Initializable {
+contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, AccessControlEnumerable, Pausable, ReentrancyGuard, Initializable {
     using SafeERC20 for IERC20;
     using PrivacyPortalFeeLib for bytes32;
 
@@ -27,12 +29,25 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
     IERC20 public underlyingToken;
     /// @notice Private pToken minted and burned against the underlying collateral.
     IPodERC20 public pToken;
+    /// @notice Factory that created this portal (fees, blacklist, rescue recipient, defaults).
+    address public factory;
     /// @notice Optional pause controller for deposits and withdrawals; zero disables pause checks.
     address public pauseController;
     /// @notice Token decimals mirrored from the underlying/pToken pair.
     uint8 public decimals;
     /// @notice When true, {depositNative} wraps native coin; withdrawals release wrapped underlying ERC20.
     bool public nativeWrappedUnderlying;
+
+    /// @notice Operator role for fee / soft-deposit controls (mirrors Privacy Bridge).
+    bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
+    /// @notice Soft deposit switch (operator); independent of pause / factory pause.
+    bool public isDepositEnabled = true;
+    /// @notice Per-portal deposit pause override (ORs with factory pause).
+    bool public depositsPausedLocal;
+    /// @notice Per-portal withdrawal pause override (ORs with factory pause).
+    bool public withdrawalsPausedLocal;
+    /// @notice Per-portal blacklist (ORs with factory blacklist).
+    mapping(address => bool) public blacklisted;
 
     /// @notice Optional per-portal deposit fee override; bytes32(0) inherits factory default.
     bytes32 internal depositFeeOverridePacked;
@@ -56,6 +71,8 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
 
     /// @notice Withdrawal state by withdrawal id.
     mapping(bytes32 => Withdrawal) public withdrawals;
+    /// @notice Deposit escrow by mint request id.
+    mapping(bytes32 => DepositEscrow) public depositEscrows;
 
     /// @notice Public ERC20 was locked and an async private pToken mint was requested.
     event DepositRequested(
@@ -64,6 +81,8 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
         uint256 amount,
         bytes32 indexed mintRequestId
     );
+    /// @notice Failed mint collateral was returned to the depositor.
+    event DepositRefunded(address indexed user, bytes32 indexed mintRequestId, uint256 amount);
     /// @notice Public withdrawal was requested and a pToken transfer-to-portal request was submitted.
     event WithdrawalRequested(
         bytes32 indexed withdrawalId,
@@ -72,10 +91,32 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
         uint256 amount,
         bytes32 transferRequestId
     );
+    /// @notice Pending withdrawal was cancelled after a failed pToken transfer.
+    event WithdrawalFailed(bytes32 indexed withdrawalId, bytes32 indexed transferRequestId);
     /// @notice Underlying collateral was released to the withdrawal recipient.
     event WithdrawalReleased(bytes32 indexed withdrawalId, address indexed recipient, uint256 amount);
     /// @notice Portal protocol fee collected on a user-facing entry point.
+    /// @dev Prefer {OperationFeesPaid} for offline indexing of portal vs PoD fee legs.
     event PortalFeeCollected(address indexed payer, uint256 amount, bool isDeposit);
+    /// @notice Full native-fee breakdown for a deposit or withdraw (offline fee accounting).
+    /// @param payer User who paid `msg.value`.
+    /// @param correlationId Mint `requestId` (deposit/wrap) or `withdrawalId` (withdraw).
+    /// @param isDeposit True for deposit/wrap; false for withdraw.
+    /// @param isNativeWrap True when the deposit wrapped native coin into the underlying.
+    /// @param portalFee Protocol fee retained by this portal (native wei).
+    /// @param podFee Native wei forwarded to the pToken/inbox for the async PoD leg.
+    /// @param podCallbackFee Native wei reserved for the PoD callback slice within `podFee`.
+    /// @param amount Principal amount in underlying token units (not a fee).
+    event OperationFeesPaid(
+        address indexed payer,
+        bytes32 indexed correlationId,
+        bool indexed isDeposit,
+        bool isNativeWrap,
+        uint256 portalFee,
+        uint256 podFee,
+        uint256 podCallbackFee,
+        uint256 amount
+    );
     /// @notice pTokens from a release were queued for batch burn.
     event PendingBurnIncreased(bytes32 indexed withdrawalId, uint256 amount, uint256 pendingBurnAmount);
     /// @notice Owner submitted a batch burn for accumulated pTokens.
@@ -88,6 +129,8 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
     event PortalFeeOverrideCleared(bool indexed isDeposit);
     /// @notice Pause controller was changed.
     event PauseControllerUpdated(address indexed pauseController);
+    /// @notice Factory binding set at initialize (immutable thereafter).
+    event FactorySet(address indexed factory);
     /// @notice Per-portal deposit/withdraw limits changed.
     event LimitsUpdated(
         uint256 minDeposit,
@@ -95,8 +138,22 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
         uint256 minWithdraw,
         uint256 maxWithdraw
     );
-    /// @notice Native token balance was swept by the owner.
-    event NativeSwept(address indexed recipient, uint256 amount);
+    /// @notice Native token was rescued to the factory rescue recipient while paused.
+    event NativeRescued(address indexed rescueRecipient, uint256 amount);
+    /// @notice ERC20 was rescued to the factory rescue recipient while paused.
+    event ERC20Rescued(address indexed token, address indexed rescueRecipient, uint256 amount);
+    /// @notice Soft deposit-enabled flag changed.
+    event DepositEnabledUpdated(bool enabled);
+    /// @notice Local deposit/withdraw pause flags changed.
+    event LocalPauseUpdated(bool depositsPaused, bool withdrawalsPaused);
+    /// @notice Operator added.
+    event OperatorAdded(address indexed account, address indexed by);
+    /// @notice Operator removed.
+    event OperatorRemoved(address indexed account, address indexed by);
+    /// @notice Address added to the portal blacklist.
+    event Blacklisted(address indexed account, address indexed by);
+    /// @notice Address removed from the portal blacklist.
+    event UnBlacklisted(address indexed account, address indexed by);
 
     /// @notice A required address was zero.
     error InvalidAddress();
@@ -126,6 +183,14 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
     error PauseControllerFault();
     /// @notice pToken transfer request has not succeeded yet.
     error PTokenTransferNotSuccessful(bytes32 requestId, IPodERC20.RequestStatus status);
+    /// @notice Deposit escrow is missing or not eligible for the requested action.
+    error DepositEscrowInvalid(bytes32 requestId, DepositEscrowStatus status);
+    /// @notice Caller is not the original depositor for this escrow.
+    error OnlyDepositUser(address caller, address user);
+    /// @notice Mint request is not {IPodERC20.RequestStatus.SystemFailed}, so escrow cannot be refunded.
+    error DepositMintNotFailed(bytes32 requestId, IPodERC20.RequestStatus status);
+    /// @notice Transfer request is not Failed/SystemFailed, so withdrawal cannot be cancelled.
+    error WithdrawTransferNotFailed(bytes32 requestId, IPodERC20.RequestStatus status);
     /// @notice Portal underlying is not configured for native wrap deposits.
     error NativeWrapDisabled();
     /// @notice Factory pause controller is not configured.
@@ -142,6 +207,12 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
     error WithdrawExceedsMaximum();
     /// @notice Invalid min/max limit configuration.
     error InvalidLimitConfiguration();
+    /// @notice Soft deposit switch is off.
+    error DepositDisabled();
+    /// @notice Cannot rescue the paired pToken.
+    error CannotRescuePToken();
+    /// @notice Native transfer failed.
+    error EthTransferFailed();
 
     /// @notice Lock implementation instance by assigning a non-zero owner placeholder.
     constructor() Ownable(address(1)) {
@@ -156,25 +227,105 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
         address underlyingToken_,
         address pToken_,
         uint8 decimals_,
-        bool nativeWrappedUnderlying_
+        bool nativeWrappedUnderlying_,
+        address factory_
     ) external initializer override {
         if (owner_ == address(0)) {
             revert OwnableInvalidOwner(owner_);
         }
-        if (underlyingToken_ == address(0) || pToken_ == address(0)) {
+        if (underlyingToken_ == address(0) || pToken_ == address(0) || factory_ == address(0)) {
             revert InvalidAddress();
         }
         _transferOwnership(owner_);
+        _grantRole(DEFAULT_ADMIN_ROLE, owner_);
+        _grantRole(OPERATOR_ROLE, owner_);
         underlyingToken = IERC20(underlyingToken_);
         pToken = IPodERC20(pToken_);
         decimals = decimals_;
         nativeWrappedUnderlying = nativeWrappedUnderlying_;
+        isDepositEnabled = true;
         maxDepositAmount = type(uint256).max;
         maxWithdrawAmount = type(uint256).max;
         minDepositAmount = 1;
         minWithdrawAmount = 1;
-        pauseController = msg.sender;
-        emit PauseControllerUpdated(msg.sender);
+        factory = factory_;
+        pauseController = factory_;
+        emit FactorySet(factory_);
+        emit PauseControllerUpdated(factory_);
+    }
+
+    /// @inheritdoc AccessControlEnumerable
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(AccessControlEnumerable)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+
+    /// @notice Register an operator (fee / soft-deposit controls).
+    function addOperator(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (account == address(0)) {
+            revert InvalidAddress();
+        }
+        _grantRole(OPERATOR_ROLE, account);
+        emit OperatorAdded(account, msg.sender);
+    }
+
+    /// @notice Revoke an operator.
+    function removeOperator(address account) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (account == address(0)) {
+            revert InvalidAddress();
+        }
+        _revokeRole(OPERATOR_ROLE, account);
+        emit OperatorRemoved(account, msg.sender);
+    }
+
+    /// @notice Whether `account` has {OPERATOR_ROLE}.
+    function isOperator(address account) external view returns (bool) {
+        return hasRole(OPERATOR_ROLE, account);
+    }
+
+    /// @notice Owner hard-pause (enables rescue). Also blocks user deposit/withdraw entry points.
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Owner unpause.
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    /// @notice Soft deposit enable/disable (operator); does not enable rescue.
+    function setIsDepositEnabled(bool enabled) external onlyRole(OPERATOR_ROLE) {
+        isDepositEnabled = enabled;
+        emit DepositEnabledUpdated(enabled);
+    }
+
+    /// @notice Per-portal pause overrides (OR with factory pause flags).
+    function setLocalPause(bool depositsPaused, bool withdrawalsPaused) external onlyOwner {
+        depositsPausedLocal = depositsPaused;
+        withdrawalsPausedLocal = withdrawalsPaused;
+        emit LocalPauseUpdated(depositsPaused, withdrawalsPaused);
+    }
+
+    /// @notice Add an address to this portal's blacklist.
+    function addToBlacklist(address account) external onlyOwner {
+        if (account == address(0)) {
+            revert InvalidAddress();
+        }
+        blacklisted[account] = true;
+        emit Blacklisted(account, msg.sender);
+    }
+
+    /// @notice Remove an address from this portal's blacklist.
+    function removeFromBlacklist(address account) external onlyOwner {
+        if (account == address(0)) {
+            revert InvalidAddress();
+        }
+        blacklisted[account] = false;
+        emit UnBlacklisted(account, msg.sender);
     }
 
     /// @notice Update per-portal deposit and withdrawal amount limits.
@@ -205,27 +356,27 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
     }
 
     /// @inheritdoc IPrivacyPortal
-    function setDepositFee(uint256 fixedFee, uint256 percentageBps, uint256 maxFee) external onlyOwner {
+    function setDepositFee(uint256 fixedFee, uint256 percentageBps, uint256 maxFee) external onlyRole(OPERATOR_ROLE) {
         bytes32 packed = PrivacyPortalFeeLib.packFeeConfig(fixedFee, percentageBps, maxFee);
         depositFeeOverridePacked = packed;
         emit PortalFeeOverrideUpdated(true, packed);
     }
 
     /// @inheritdoc IPrivacyPortal
-    function setWithdrawFee(uint256 fixedFee, uint256 percentageBps, uint256 maxFee) external onlyOwner {
+    function setWithdrawFee(uint256 fixedFee, uint256 percentageBps, uint256 maxFee) external onlyRole(OPERATOR_ROLE) {
         bytes32 packed = PrivacyPortalFeeLib.packFeeConfig(fixedFee, percentageBps, maxFee);
         withdrawFeeOverridePacked = packed;
         emit PortalFeeOverrideUpdated(false, packed);
     }
 
     /// @inheritdoc IPrivacyPortal
-    function clearDepositFeeOverride() external onlyOwner {
+    function clearDepositFeeOverride() external onlyRole(OPERATOR_ROLE) {
         depositFeeOverridePacked = bytes32(0);
         emit PortalFeeOverrideCleared(true);
     }
 
     /// @inheritdoc IPrivacyPortal
-    function clearWithdrawFeeOverride() external onlyOwner {
+    function clearWithdrawFeeOverride() external onlyRole(OPERATOR_ROLE) {
         withdrawFeeOverridePacked = bytes32(0);
         emit PortalFeeOverrideCleared(false);
     }
@@ -262,8 +413,17 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
 
         underlyingToken.safeTransferFrom(msg.sender, address(this), amount);
         requestId = pToken.mint{value: mintFee}(recipient, amount, mintCallbackFee);
+        depositEscrows[requestId] = DepositEscrow({
+            user: msg.sender,
+            recipient: recipient,
+            amount: amount,
+            status: DepositEscrowStatus.Pending
+        });
         emit DepositRequested(msg.sender, recipient, amount, requestId);
         emit WrapRequested(msg.sender, recipient, amount, requestId);
+        emit OperationFeesPaid(
+            msg.sender, requestId, true, false, portalFee, mintFee, mintCallbackFee, amount
+        );
     }
 
     /// @inheritdoc IPrivacyPortal
@@ -294,8 +454,17 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
 
         IWrappedNative(address(underlyingToken)).deposit{value: amount}();
         requestId = pToken.mint{value: mintFee}(recipient, amount, mintCallbackFee);
+        depositEscrows[requestId] = DepositEscrow({
+            user: msg.sender,
+            recipient: recipient,
+            amount: amount,
+            status: DepositEscrowStatus.Pending
+        });
         emit DepositRequested(msg.sender, recipient, amount, requestId);
         emit WrapRequested(msg.sender, recipient, amount, requestId);
+        emit OperationFeesPaid(
+            msg.sender, requestId, true, true, portalFee, mintFee, mintCallbackFee, amount
+        );
     }
 
     /// @inheritdoc IERC7984PortalWrapper
@@ -378,6 +547,16 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
             withdrawalId,
             keccak256(abi.encode(withdrawalId, transferRequestId))
         );
+        emit OperationFeesPaid(
+            msg.sender,
+            withdrawalId,
+            false,
+            false,
+            portalFee,
+            transferTotalFee,
+            transferCallbackFee,
+            amount
+        );
     }
 
     /// @inheritdoc IPrivacyPortal
@@ -386,6 +565,50 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
             revert OnlyPToken(msg.sender);
         }
         _releaseWithdrawal(withdrawalId);
+    }
+
+    /// @inheritdoc IPrivacyPortal
+    function refundFailedDeposit(bytes32 requestId) external override nonReentrant {
+        DepositEscrow storage escrow = depositEscrows[requestId];
+        DepositEscrowStatus status = escrow.status;
+        if (status != DepositEscrowStatus.Pending && status != DepositEscrowStatus.Failed) {
+            revert DepositEscrowInvalid(requestId, status);
+        }
+        if (msg.sender != escrow.user) {
+            revert OnlyDepositUser(msg.sender, escrow.user);
+        }
+        IPodERC20.RequestStatus mintStatus = pToken.requests(requestId).status;
+        // Mint should not `raise`; only Inbox system errors are refundable.
+        if (mintStatus != IPodERC20.RequestStatus.SystemFailed) {
+            revert DepositMintNotFailed(requestId, mintStatus);
+        }
+
+        uint256 amount = escrow.amount;
+        escrow.status = DepositEscrowStatus.Refunded;
+        escrow.amount = 0;
+        underlyingToken.safeTransfer(escrow.user, amount);
+        emit DepositRefunded(escrow.user, requestId, amount);
+    }
+
+    /// @inheritdoc IPrivacyPortal
+    function cancelFailedWithdrawal(bytes32 withdrawalId) external override nonReentrant {
+        Withdrawal storage withdrawal = withdrawals[withdrawalId];
+        if (withdrawal.user == address(0)) {
+            revert UnknownWithdrawal(withdrawalId);
+        }
+        if (withdrawal.status != WithdrawalStatus.TransferPending) {
+            revert WithdrawalNotPending(withdrawalId, withdrawal.status);
+        }
+        IPodERC20.RequestStatus requestStatus = pToken.requests(withdrawal.transferRequestId).status;
+        if (
+            requestStatus != IPodERC20.RequestStatus.Failed
+                && requestStatus != IPodERC20.RequestStatus.SystemFailed
+        ) {
+            revert WithdrawTransferNotFailed(withdrawal.transferRequestId, requestStatus);
+        }
+
+        withdrawal.status = WithdrawalStatus.Failed;
+        emit WithdrawalFailed(withdrawalId, withdrawal.transferRequestId);
     }
 
     /// @inheritdoc IPrivacyPortal
@@ -425,8 +648,8 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
             revert InsufficientAccumulatedFees(accumulatedPortalFees, amount);
         }
 
-        IPrivacyPortalFactory factory = _factory();
-        address recipient = factory.feeRecipient();
+        IPrivacyPortalFactory portalFactory = _factory();
+        address recipient = portalFactory.feeRecipient();
         if (recipient == address(0)) {
             revert InvalidAddress();
         }
@@ -437,17 +660,41 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
         emit PortalFeesWithdrawn(recipient, amount);
     }
 
-    /// @inheritdoc IPrivacyPortal
-    function sweepNative(address payable recipient, uint256 amount) external onlyOwner nonReentrant {
-        if (recipient == address(0)) {
-            revert InvalidAddress();
-        }
+    /// @notice Rescue native balance to the factory rescue recipient while paused (catastrophe path).
+    function rescueNative(uint256 amount) external onlyOwner nonReentrant whenPaused {
         if (amount == 0) {
             revert InvalidAmount();
         }
-        (bool ok,) = recipient.call{value: amount}("");
-        require(ok, "PrivacyPortal: sweep failed");
-        emit NativeSwept(recipient, amount);
+        address recipient = _factory().rescueRecipient();
+        if (recipient == address(0)) {
+            revert InvalidAddress();
+        }
+        (bool ok,) = payable(recipient).call{value: amount}("");
+        if (!ok) {
+            revert EthTransferFailed();
+        }
+        // Keep fee accounting consistent if rescue dips into fee balance.
+        uint256 bal = address(this).balance;
+        if (accumulatedPortalFees > bal) {
+            accumulatedPortalFees = bal;
+        }
+        emit NativeRescued(recipient, amount);
+    }
+
+    /// @notice Rescue ERC20 balance to the factory rescue recipient while paused. Cannot rescue the paired pToken.
+    function rescueERC20(address token, uint256 amount) external onlyOwner nonReentrant whenPaused {
+        if (token == address(0) || amount == 0) {
+            revert InvalidAmount();
+        }
+        if (token == address(pToken)) {
+            revert CannotRescuePToken();
+        }
+        address recipient = _factory().rescueRecipient();
+        if (recipient == address(0)) {
+            revert InvalidAddress();
+        }
+        IERC20(token).safeTransfer(recipient, amount);
+        emit ERC20Rescued(token, recipient, amount);
     }
 
     /// @inheritdoc IPrivacyPortal
@@ -527,7 +774,7 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
         if (withdrawal.status != WithdrawalStatus.TransferPending) {
             revert WithdrawalNotPending(withdrawalId, withdrawal.status);
         }
-        IPodERC20.RequestStatus requestStatus = pToken.requests(withdrawal.transferRequestId);
+        IPodERC20.RequestStatus requestStatus = pToken.requests(withdrawal.transferRequestId).status;
         if (requestStatus != IPodERC20.RequestStatus.Success) {
             revert PTokenTransferNotSuccessful(withdrawal.transferRequestId, requestStatus);
         }
@@ -564,15 +811,15 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
         returns (uint256 floor, uint128 maxFee)
     {
         bytes32 packed = _effectiveFeePacked(isDeposit);
-        IPrivacyPortalFactory factory = _factory();
+        IPrivacyPortalFactory portalFactory = _factory();
         (uint96 fixedFee, uint32 bps, uint128 max) = PrivacyPortalFeeLib.unpackFeeConfig(packed);
         maxFee = max;
-        if (address(factory.priceOracle()) == address(0) || bps == 0) {
+        if (address(portalFactory.priceOracle()) == address(0) || bps == 0) {
             return (fixedFee, maxFee);
         }
-        IPodPriceOracle oracle = factory.priceOracle();
+        IPodPriceOracle oracle = portalFactory.priceOracle();
         (uint256 nativeUsd, uint256 collateralUsd) = oracle.getLivePrices(
-            factory.nativeToken(),
+            portalFactory.nativeToken(),
             address(underlyingToken)
         );
         (floor,) = PrivacyPortalFeeLib.resolvePortalFee(
@@ -589,31 +836,31 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
         view
         returns (uint256 fee, bool usedDynamicPricing)
     {
-        IPrivacyPortalFactory factory = _factory();
+        IPrivacyPortalFactory portalFactory = _factory();
         if (isDeposit) {
             if (PrivacyPortalFeeLib.isOverrideSet(depositFeeOverridePacked)) {
-                return _estimateWithOverride(depositFeeOverridePacked, amount, factory);
+                return _estimateWithOverride(depositFeeOverridePacked, amount, portalFactory);
             }
-            return factory.estimateDepositPortalFee(address(underlyingToken), amount, decimals);
+            return portalFactory.estimateDepositPortalFee(address(underlyingToken), amount, decimals);
         }
         if (PrivacyPortalFeeLib.isOverrideSet(withdrawFeeOverridePacked)) {
-            return _estimateWithOverride(withdrawFeeOverridePacked, amount, factory);
+            return _estimateWithOverride(withdrawFeeOverridePacked, amount, portalFactory);
         }
-        return factory.estimateWithdrawPortalFee(address(underlyingToken), amount, decimals);
+        return portalFactory.estimateWithdrawPortalFee(address(underlyingToken), amount, decimals);
     }
 
-    function _estimateWithOverride(bytes32 packed, uint256 amount, IPrivacyPortalFactory factory)
+    function _estimateWithOverride(bytes32 packed, uint256 amount, IPrivacyPortalFactory portalFactory)
         private
         view
         returns (uint256 fee, bool usedDynamicPricing)
     {
-        if (address(factory.priceOracle()) == address(0)) {
+        if (address(portalFactory.priceOracle()) == address(0)) {
             (uint96 fixedFee,,) = PrivacyPortalFeeLib.unpackFeeConfig(packed);
             return (fixedFee, false);
         }
-        IPodPriceOracle oracle = factory.priceOracle();
+        IPodPriceOracle oracle = portalFactory.priceOracle();
         (uint256 nativeUsd, uint256 collateralUsd) = oracle.getLivePrices(
-            factory.nativeToken(),
+            portalFactory.nativeToken(),
             address(underlyingToken)
         );
         return PrivacyPortalFeeLib.resolvePortalFee(
@@ -630,32 +877,41 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Ownable, Reentr
         if (PrivacyPortalFeeLib.isOverrideSet(overridePacked)) {
             return overridePacked;
         }
-        IPrivacyPortalFactory factory = _factory();
-        return isDeposit ? factory.defaultDepositFeePacked() : factory.defaultWithdrawFeePacked();
+        IPrivacyPortalFactory portalFactory = _factory();
+        return isDeposit ? portalFactory.defaultDepositFeePacked() : portalFactory.defaultWithdrawFeePacked();
     }
 
     function _factory() private view returns (IPrivacyPortalFactory) {
-        address controller = pauseController;
-        if (controller == address(0)) {
+        address factory_ = factory;
+        if (factory_ == address(0)) {
             revert FactoryNotConfigured();
         }
-        return IPrivacyPortalFactory(controller);
+        return IPrivacyPortalFactory(factory_);
     }
 
     function _checkWithdrawalsNotPaused() private view {
-        if (_pauseFlag(IPrivacyPortalPauseController.withdrawalsPaused.selector)) {
+        if (paused()) {
+            revert WithdrawalsPaused();
+        }
+        if (withdrawalsPausedLocal || _pauseFlag(IPrivacyPortalPauseController.withdrawalsPaused.selector)) {
             revert WithdrawalsPaused();
         }
     }
 
     function _checkDepositsNotPaused() private view {
-        if (_pauseFlag(IPrivacyPortalPauseController.depositsPaused.selector)) {
+        if (paused()) {
+            revert DepositsPaused();
+        }
+        if (!isDepositEnabled) {
+            revert DepositDisabled();
+        }
+        if (depositsPausedLocal || _pauseFlag(IPrivacyPortalPauseController.depositsPaused.selector)) {
             revert DepositsPaused();
         }
     }
 
     function _checkNotBlacklisted() private view {
-        if (_factory().blacklisted(msg.sender)) {
+        if (blacklisted[msg.sender] || _factory().blacklisted(msg.sender)) {
             revert AddressBlacklisted(msg.sender);
         }
     }

--- a/contracts/pod/privacy/PrivacyPortalFactory.sol
+++ b/contracts/pod/privacy/PrivacyPortalFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/proxy/Clones.sol";
 import "@openzeppelin/contracts/utils/Pausable.sol";
@@ -17,16 +17,19 @@ import "./PrivacyPortalFeeLib.sol";
 
 /// @title PrivacyPortalFactory
 /// @notice Deploys one-shot minimal-clone portals and pTokens for public ERC20 collateral.
-/// @dev Governance uses OpenZeppelin {AccessControlEnumerable}: {DEFAULT_ADMIN_ROLE} for admin actions,
+/// @dev Governance uses OpenZeppelin {AccessControl}: {DEFAULT_ADMIN_ROLE} for admin actions,
 ///      {OPERATOR_ROLE} for factory default fees and portal fee / soft-deposit controls. Manage roles via
 ///      {grantRole} and {revokeRole}. Portals have no local operator role — they call {isOperator}.
 ///      Admin {pause}/{unpause} pauses deposits and withdrawals on every portal from this factory.
-contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable, Pausable {
+///      Uses plain {AccessControl} (not Enumerable) so bytecode stays Paris-compatible for COTI.
+contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControl, Pausable {
     using PrivacyPortalFeeLib for bytes32;
 
     /// @notice Operator role for routine fee-parameter updates (mirrors Privacy Bridge).
     bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
 
+    /// @dev Primary admin for {owner()} tooling; kept in sync with {DEFAULT_ADMIN_ROLE} grants/revokes.
+    address private _owner;
     /// @notice Source-chain inbox used by pToken clones and registration messages.
     address public inbox;
     /// @notice COTI chain id used by pToken clones for remote MPC execution.
@@ -178,14 +181,34 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable,
         }
     }
 
-    /// @notice Primary factory admin: first holder of {DEFAULT_ADMIN_ROLE}.
-    /// @dev Mirrors `Ownable.owner()` for tooling compatibility. When multiple admins exist,
-    ///      returns `getRoleMember(DEFAULT_ADMIN_ROLE, 0)` (enumeration order).
+    /// @notice Primary factory admin for tooling (`Ownable.owner()`-shaped).
+    /// @dev Tracks the first granted {DEFAULT_ADMIN_ROLE}; clears when that account is revoked.
     function owner() external view returns (address) {
-        if (getRoleMemberCount(DEFAULT_ADMIN_ROLE) == 0) {
+        if (_owner == address(0) || !hasRole(DEFAULT_ADMIN_ROLE, _owner)) {
             revert AdminNotConfigured();
         }
-        return getRoleMember(DEFAULT_ADMIN_ROLE, 0);
+        return _owner;
+    }
+
+    /// @notice Whether `account` holds {DEFAULT_ADMIN_ROLE}.
+    function isAdmin(address account) external view returns (bool) {
+        return hasRole(DEFAULT_ADMIN_ROLE, account);
+    }
+
+    function _grantRole(bytes32 role, address account) internal override returns (bool) {
+        bool granted = super._grantRole(role, account);
+        if (granted && role == DEFAULT_ADMIN_ROLE && _owner == address(0)) {
+            _owner = account;
+        }
+        return granted;
+    }
+
+    function _revokeRole(bytes32 role, address account) internal override returns (bool) {
+        bool revoked = super._revokeRole(role, account);
+        if (revoked && role == DEFAULT_ADMIN_ROLE && account == _owner) {
+            _owner = address(0);
+        }
+        return revoked;
     }
 
     /// @notice Whether `account` holds {OPERATOR_ROLE}.
@@ -378,10 +401,9 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable,
         string calldata name,
         string calldata symbol,
         uint8 decimals,
-        bool nativeWrappedUnderlying,
-        address portalOwner
+        bool nativeWrappedUnderlying
     ) external payable onlyDeployer returns (address portal, address pToken) {
-        if (underlying == address(0) || portalOwner == address(0)) {
+        if (underlying == address(0)) {
             revert InvalidAddress();
         }
         if (portalForUnderlying[underlying] != address(0)) {
@@ -392,7 +414,7 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable,
         pToken = Clones.clone(podTokenImplementation);
 
         // Factory retains Ownable on the pToken so admins can {configurePToken} after inbox / mother upgrades.
-        // Portal minter is the portal; portal Ownable is `portalOwner`.
+        // Portal minter is the portal; portal admin is factory {DEFAULT_ADMIN_ROLE} (no local Ownable).
         PodErc20MintableInitializable(payable(pToken)).initialize(
             portal,
             address(this),
@@ -404,7 +426,7 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable,
             decimals
         );
         IPrivacyPortal(portal).initialize(
-            portalOwner, underlying, pToken, decimals, nativeWrappedUnderlying, address(this)
+            underlying, pToken, decimals, nativeWrappedUnderlying, address(this)
         );
 
         portalForUnderlying[underlying] = portal;

--- a/contracts/pod/privacy/PrivacyPortalFactory.sol
+++ b/contracts/pod/privacy/PrivacyPortalFactory.sol
@@ -40,8 +40,8 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControl, Pausable 
     address public immutable podTokenImplementation;
     /// @notice Clone implementation for portals.
     address public immutable portalImplementation;
-    /// @notice Recipient of swept portal protocol fees from all portals created here.
-    address public feeRecipient;
+    /// @notice Recipient of swept portal protocol fees from all portals created here (fixed at deploy; no setter).
+    address public immutable feeRecipient;
     /// @notice Catastrophe rescue destination for all portals created here (pause + owner rescue).
     address public rescueRecipient;
     /// @notice Wrapped native token on this chain (WETH/WAVAX) for portal gas fee pricing.
@@ -87,8 +87,6 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControl, Pausable 
     event PriceOracleUpdated(address indexed previousOracle, address indexed newOracle);
     /// @notice Inbox / COTI mother routing updated for newly created portals and registration messages.
     event RoutingUpdated(address indexed inbox, uint256 cotiChainId, address indexed cotiMotherContract);
-    /// @notice Fee recipient updated for swept portal protocol fees.
-    event FeeRecipientUpdated(address indexed previousRecipient, address indexed newRecipient);
     /// @notice Rescue recipient updated for paused portal rescue paths.
     event RescueRecipientUpdated(address indexed previousRecipient, address indexed newRecipient);
 
@@ -119,7 +117,7 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControl, Pausable 
     /// @param cotiMotherContract_ Unified COTI-side pToken ledger.
     /// @param podTokenImplementation_ Clone implementation for source-chain pTokens.
     /// @param portalImplementation_ Clone implementation for portals.
-    /// @param feeRecipient_ Recipient of swept portal protocol fees.
+    /// @param feeRecipient_ Recipient of swept portal protocol fees (immutable for factory lifetime).
     /// @param rescueRecipient_ Catastrophe rescue destination for portals from this factory.
     /// @param nativeToken_ Wrapped native token (WETH/WAVAX) for dynamic fee gas pricing.
     /// @param priceOracle_ Optional USD oracle; zero for min-fee-only deployments.
@@ -278,16 +276,6 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControl, Pausable 
             revert InvalidAddress();
         }
         Ownable(pToken_).transferOwnership(newOwner_);
-    }
-
-    /// @notice Admin: rotate the recipient of swept portal protocol fees.
-    function setFeeRecipient(address feeRecipient_) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (feeRecipient_ == address(0)) {
-            revert InvalidAddress();
-        }
-        address previous = feeRecipient;
-        feeRecipient = feeRecipient_;
-        emit FeeRecipientUpdated(previous, feeRecipient_);
     }
 
     /// @notice Admin: rotate the catastrophe rescue destination used by all portals from this factory.

--- a/contracts/pod/privacy/PrivacyPortalFactory.sol
+++ b/contracts/pod/privacy/PrivacyPortalFactory.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/proxy/Clones.sol";
+import "@openzeppelin/contracts/utils/Pausable.sol";
 
 import "../IInbox.sol";
 import "../token/perc20/IPodERC20.sol";
@@ -17,8 +18,10 @@ import "./PrivacyPortalFeeLib.sol";
 /// @title PrivacyPortalFactory
 /// @notice Deploys one-shot minimal-clone portals and pTokens for public ERC20 collateral.
 /// @dev Governance uses OpenZeppelin {AccessControlEnumerable}: {DEFAULT_ADMIN_ROLE} for admin actions,
-///      {OPERATOR_ROLE} for default fee updates. Manage roles via {grantRole} and {revokeRole}.
-contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable {
+///      {OPERATOR_ROLE} for factory default fees and portal fee / soft-deposit controls. Manage roles via
+///      {grantRole} and {revokeRole}. Portals have no local operator role — they call {isOperator}.
+///      Admin {pause}/{unpause} pauses deposits and withdrawals on every portal from this factory.
+contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable, Pausable {
     using PrivacyPortalFeeLib for bytes32;
 
     /// @notice Operator role for routine fee-parameter updates (mirrors Privacy Bridge).
@@ -40,18 +43,9 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
     address public rescueRecipient;
     /// @notice Wrapped native token on this chain (WETH/WAVAX) for portal gas fee pricing.
     address public immutable nativeToken;
-    /// @notice Global flag exposed through the pause-controller interface for all portals created here.
-    bool public withdrawalsPaused;
-    /// @notice Global flag exposed through the pause-controller interface for deposits on factory-created portals.
-    bool public depositsPaused;
 
     /// @notice Optional USD oracle for dynamic portal fees; zero disables dynamic pricing.
     IPodPriceOracle public priceOracle;
-    /// @notice Admin knob mirroring Privacy Bridge freshness policy.
-    /// @dev Current {IPodPriceOracle} adapters already return `0` when stale (fixed-fee fallback). Kept for ops parity
-    ///      and future timestamp-aware fee binding; not enforced in fee math today.
-    uint256 public constant DEFAULT_MAX_ORACLE_AGE = 30 minutes + 5 minutes;
-    uint256 public maxOracleAge;
     /// @notice Factory default packed deposit fee config.
     bytes32 public defaultDepositFeePacked;
     /// @notice Factory default packed withdraw fee config.
@@ -74,12 +68,6 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
     event UnBlacklisted(address indexed account, address indexed by);
     /// @notice Deployer allowlist entry changed.
     event DeployerUpdated(address indexed deployer, bool allowed);
-    /// @notice Global withdrawal pause flag changed.
-    event WithdrawalsPausedUpdated(bool paused);
-    /// @notice Global deposit pause flag changed.
-    event DepositsPausedUpdated(bool paused);
-    /// @notice Both deposit and withdrawal pause flags changed together (emergency circuit breaker).
-    event OperationsPausedUpdated(bool paused);
     /// @notice A new portal and source-chain pToken clone pair was deployed.
     event PortalCreated(
         address indexed underlying,
@@ -94,8 +82,6 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
     event DefaultPortalFeeUpdated(bool indexed isDeposit, bytes32 packedConfig);
     /// @notice Portal fee oracle upgraded or disabled.
     event PriceOracleUpdated(address indexed previousOracle, address indexed newOracle);
-    /// @notice Max oracle age admin knob updated (see {maxOracleAge} docs).
-    event MaxOracleAgeUpdated(uint256 previousAge, uint256 newAge);
     /// @notice Inbox / COTI mother routing updated for newly created portals and registration messages.
     event RoutingUpdated(address indexed inbox, uint256 cotiChainId, address indexed cotiMotherContract);
     /// @notice Fee recipient updated for swept portal protocol fees.
@@ -115,8 +101,6 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
     error OracleNotConfigured();
     /// @notice No {DEFAULT_ADMIN_ROLE} holder is configured.
     error AdminNotConfigured();
-    /// @notice maxOracleAge cannot be zero.
-    error OracleMaxAgeZeroDisallowed();
 
     /// @notice Restrict a function to an allowlisted deployer.
     modifier onlyDeployer() {
@@ -177,7 +161,6 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
         rescueRecipient = rescueRecipient_;
         nativeToken = nativeToken_;
         priceOracle = IPodPriceOracle(priceOracle_);
-        maxOracleAge = DEFAULT_MAX_ORACLE_AGE;
         defaultDepositFeePacked = PrivacyPortalFeeLib.packFeeConfig(
             defaultDepositFixedFee_, defaultDepositPercentageBps_, defaultDepositMaxFee_
         );
@@ -203,6 +186,11 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
             revert AdminNotConfigured();
         }
         return getRoleMember(DEFAULT_ADMIN_ROLE, 0);
+    }
+
+    /// @notice Whether `account` holds {OPERATOR_ROLE}.
+    function isOperator(address account) external view returns (bool) {
+        return hasRole(OPERATOR_ROLE, account);
     }
 
     /// @notice Add an address to the factory blacklist, blocking deposits and withdrawals on all portals here.
@@ -289,25 +277,24 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
         emit RescueRecipientUpdated(previous, rescueRecipient_);
     }
 
-    /// @notice Set the global pause flag read by portals initialized from this factory.
-    function setWithdrawalsPaused(bool paused) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        withdrawalsPaused = paused;
-        emit WithdrawalsPausedUpdated(paused);
+    /// @notice Pause deposits and withdrawals on every portal from this factory.
+    function pause() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _pause();
     }
 
-    /// @notice Set the global deposit pause flag read by portals initialized from this factory.
-    function setDepositsPaused(bool paused) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        depositsPaused = paused;
-        emit DepositsPausedUpdated(paused);
+    /// @notice Unpause factory-wide deposit and withdrawal entry points.
+    function unpause() external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _unpause();
     }
 
-    /// @notice Pause or unpause both deposits and withdrawals (emergency circuit breaker).
-    function setOperationsPaused(bool paused) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        withdrawalsPaused = paused;
-        depositsPaused = paused;
-        emit OperationsPausedUpdated(paused);
-        emit WithdrawalsPausedUpdated(paused);
-        emit DepositsPausedUpdated(paused);
+    /// @inheritdoc IPrivacyPortalPauseController
+    function depositsPaused() external view returns (bool) {
+        return paused();
+    }
+
+    /// @inheritdoc IPrivacyPortalPauseController
+    function withdrawalsPaused() external view returns (bool) {
+        return paused();
     }
 
     /// @notice Update factory default deposit fee config.
@@ -335,16 +322,6 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
         address previous = address(priceOracle);
         priceOracle = IPodPriceOracle(newOracle);
         emit PriceOracleUpdated(previous, newOracle);
-    }
-
-    /// @notice Set max oracle age (ops parity with Privacy Bridge). Zero disallowed.
-    function setMaxOracleAge(uint256 maxOracleAge_) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (maxOracleAge_ == 0) {
-            revert OracleMaxAgeZeroDisallowed();
-        }
-        uint256 previous = maxOracleAge;
-        maxOracleAge = maxOracleAge_;
-        emit MaxOracleAgeUpdated(previous, maxOracleAge_);
     }
 
     /// @inheritdoc IPrivacyPortalFactory

--- a/contracts/pod/privacy/PrivacyPortalFactory.sol
+++ b/contracts/pod/privacy/PrivacyPortalFactory.sol
@@ -2,9 +2,11 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/access/extensions/AccessControlEnumerable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/proxy/Clones.sol";
 
 import "../IInbox.sol";
+import "../token/perc20/IPodERC20.sol";
 import "../token/perc20/PodErc20MintableInitializable.sol";
 import "../token/perc20/cotiside/PodErc20CotiMother.sol";
 import "./IPrivacyPortal.sol";
@@ -23,17 +25,19 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
     bytes32 public constant OPERATOR_ROLE = keccak256("OPERATOR_ROLE");
 
     /// @notice Source-chain inbox used by pToken clones and registration messages.
-    address public immutable inbox;
+    address public inbox;
     /// @notice COTI chain id used by pToken clones for remote MPC execution.
-    uint256 public immutable cotiChainId;
+    uint256 public cotiChainId;
     /// @notice Unified COTI-side pToken ledger all clones talk to.
-    address public immutable cotiMotherContract;
+    address public cotiMotherContract;
     /// @notice Clone implementation for source-chain pTokens.
     address public immutable podTokenImplementation;
     /// @notice Clone implementation for portals.
     address public immutable portalImplementation;
     /// @notice Recipient of swept portal protocol fees from all portals created here.
-    address public immutable feeRecipient;
+    address public feeRecipient;
+    /// @notice Catastrophe rescue destination for all portals created here (pause + owner rescue).
+    address public rescueRecipient;
     /// @notice Wrapped native token on this chain (WETH/WAVAX) for portal gas fee pricing.
     address public immutable nativeToken;
     /// @notice Global flag exposed through the pause-controller interface for all portals created here.
@@ -43,6 +47,11 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
 
     /// @notice Optional USD oracle for dynamic portal fees; zero disables dynamic pricing.
     IPodPriceOracle public priceOracle;
+    /// @notice Admin knob mirroring Privacy Bridge freshness policy.
+    /// @dev Current {IPodPriceOracle} adapters already return `0` when stale (fixed-fee fallback). Kept for ops parity
+    ///      and future timestamp-aware fee binding; not enforced in fee math today.
+    uint256 public constant DEFAULT_MAX_ORACLE_AGE = 30 minutes + 5 minutes;
+    uint256 public maxOracleAge;
     /// @notice Factory default packed deposit fee config.
     bytes32 public defaultDepositFeePacked;
     /// @notice Factory default packed withdraw fee config.
@@ -85,6 +94,14 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
     event DefaultPortalFeeUpdated(bool indexed isDeposit, bytes32 packedConfig);
     /// @notice Portal fee oracle upgraded or disabled.
     event PriceOracleUpdated(address indexed previousOracle, address indexed newOracle);
+    /// @notice Max oracle age admin knob updated (see {maxOracleAge} docs).
+    event MaxOracleAgeUpdated(uint256 previousAge, uint256 newAge);
+    /// @notice Inbox / COTI mother routing updated for newly created portals and registration messages.
+    event RoutingUpdated(address indexed inbox, uint256 cotiChainId, address indexed cotiMotherContract);
+    /// @notice Fee recipient updated for swept portal protocol fees.
+    event FeeRecipientUpdated(address indexed previousRecipient, address indexed newRecipient);
+    /// @notice Rescue recipient updated for paused portal rescue paths.
+    event RescueRecipientUpdated(address indexed previousRecipient, address indexed newRecipient);
 
     /// @notice Caller is not an allowlisted deployer.
     error OnlyDeployer(address caller);
@@ -92,10 +109,14 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
     error InvalidAddress();
     /// @notice A portal already exists for the underlying token.
     error PortalAlreadyExists(address underlying, address portal);
+    /// @notice pToken is not registered to a portal created by this factory.
+    error UnknownPToken(address pToken);
     /// @notice Oracle is not configured.
     error OracleNotConfigured();
     /// @notice No {DEFAULT_ADMIN_ROLE} holder is configured.
     error AdminNotConfigured();
+    /// @notice maxOracleAge cannot be zero.
+    error OracleMaxAgeZeroDisallowed();
 
     /// @notice Restrict a function to an allowlisted deployer.
     modifier onlyDeployer() {
@@ -112,6 +133,7 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
     /// @param podTokenImplementation_ Clone implementation for source-chain pTokens.
     /// @param portalImplementation_ Clone implementation for portals.
     /// @param feeRecipient_ Recipient of swept portal protocol fees.
+    /// @param rescueRecipient_ Catastrophe rescue destination for portals from this factory.
     /// @param nativeToken_ Wrapped native token (WETH/WAVAX) for dynamic fee gas pricing.
     /// @param priceOracle_ Optional USD oracle; zero for min-fee-only deployments.
     /// @param defaultDepositFixedFee_ Default deposit fee floor in native wei.
@@ -128,6 +150,7 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
         address podTokenImplementation_,
         address portalImplementation_,
         address feeRecipient_,
+        address rescueRecipient_,
         address nativeToken_,
         address priceOracle_,
         uint256 defaultDepositFixedFee_,
@@ -141,7 +164,7 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
             initialOwner == address(0) || inbox_ == address(0) || cotiChainId_ == 0
                 || cotiMotherContract_ == address(0) || podTokenImplementation_ == address(0)
                 || portalImplementation_ == address(0) || feeRecipient_ == address(0)
-                || nativeToken_ == address(0)
+                || rescueRecipient_ == address(0) || nativeToken_ == address(0)
         ) {
             revert InvalidAddress();
         }
@@ -151,8 +174,10 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
         podTokenImplementation = podTokenImplementation_;
         portalImplementation = portalImplementation_;
         feeRecipient = feeRecipient_;
+        rescueRecipient = rescueRecipient_;
         nativeToken = nativeToken_;
         priceOracle = IPodPriceOracle(priceOracle_);
+        maxOracleAge = DEFAULT_MAX_ORACLE_AGE;
         defaultDepositFeePacked = PrivacyPortalFeeLib.packFeeConfig(
             defaultDepositFixedFee_, defaultDepositPercentageBps_, defaultDepositMaxFee_
         );
@@ -207,6 +232,63 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
         emit DeployerUpdated(deployer, allowed);
     }
 
+    /// @notice Admin: rotate inbox, COTI chain id, and mother ledger used for new portals / registration.
+    /// @dev Existing pToken clones keep their peer until {configurePToken} (factory is their Ownable owner).
+    function configureRouting(address inbox_, uint256 cotiChainId_, address cotiMotherContract_)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        if (inbox_ == address(0) || cotiChainId_ == 0 || cotiMotherContract_ == address(0)) {
+            revert InvalidAddress();
+        }
+        inbox = inbox_;
+        cotiChainId = cotiChainId_;
+        cotiMotherContract = cotiMotherContract_;
+        emit RoutingUpdated(inbox_, cotiChainId_, cotiMotherContract_);
+    }
+
+    /// @notice Admin: rotate inbox / COTI peer on an existing factory-deployed pToken clone ({cotiChainId} is immutable on the token).
+    function configurePToken(address pToken_, address inbox_, address cotiSideContract_)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        if (portalForPToken[pToken_] == address(0)) {
+            revert UnknownPToken(pToken_);
+        }
+        IPodERC20(pToken_).configure(inbox_, cotiSideContract_);
+    }
+
+    /// @notice Admin: transfer Ownable of a factory-deployed pToken (e.g. hand off after launch).
+    function transferPTokenOwnership(address pToken_, address newOwner_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (portalForPToken[pToken_] == address(0)) {
+            revert UnknownPToken(pToken_);
+        }
+        if (newOwner_ == address(0)) {
+            revert InvalidAddress();
+        }
+        Ownable(pToken_).transferOwnership(newOwner_);
+    }
+
+    /// @notice Admin: rotate the recipient of swept portal protocol fees.
+    function setFeeRecipient(address feeRecipient_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (feeRecipient_ == address(0)) {
+            revert InvalidAddress();
+        }
+        address previous = feeRecipient;
+        feeRecipient = feeRecipient_;
+        emit FeeRecipientUpdated(previous, feeRecipient_);
+    }
+
+    /// @notice Admin: rotate the catastrophe rescue destination used by all portals from this factory.
+    function setRescueRecipient(address rescueRecipient_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (rescueRecipient_ == address(0)) {
+            revert InvalidAddress();
+        }
+        address previous = rescueRecipient;
+        rescueRecipient = rescueRecipient_;
+        emit RescueRecipientUpdated(previous, rescueRecipient_);
+    }
+
     /// @notice Set the global pause flag read by portals initialized from this factory.
     function setWithdrawalsPaused(bool paused) external onlyRole(DEFAULT_ADMIN_ROLE) {
         withdrawalsPaused = paused;
@@ -253,6 +335,16 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
         address previous = address(priceOracle);
         priceOracle = IPodPriceOracle(newOracle);
         emit PriceOracleUpdated(previous, newOracle);
+    }
+
+    /// @notice Set max oracle age (ops parity with Privacy Bridge). Zero disallowed.
+    function setMaxOracleAge(uint256 maxOracleAge_) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        if (maxOracleAge_ == 0) {
+            revert OracleMaxAgeZeroDisallowed();
+        }
+        uint256 previous = maxOracleAge;
+        maxOracleAge = maxOracleAge_;
+        emit MaxOracleAgeUpdated(previous, maxOracleAge_);
     }
 
     /// @inheritdoc IPrivacyPortalFactory
@@ -322,8 +414,11 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
         portal = Clones.clone(portalImplementation);
         pToken = Clones.clone(podTokenImplementation);
 
+        // Factory retains Ownable on the pToken so admins can {configurePToken} after inbox / mother upgrades.
+        // Portal minter is the portal; portal Ownable is `portalOwner`.
         PodErc20MintableInitializable(payable(pToken)).initialize(
             portal,
+            address(this),
             cotiChainId,
             inbox,
             cotiMotherContract,
@@ -331,7 +426,9 @@ contract PrivacyPortalFactory is IPrivacyPortalFactory, AccessControlEnumerable 
             symbol,
             decimals
         );
-        IPrivacyPortal(portal).initialize(portalOwner, underlying, pToken, decimals, nativeWrappedUnderlying);
+        IPrivacyPortal(portal).initialize(
+            portalOwner, underlying, pToken, decimals, nativeWrappedUnderlying, address(this)
+        );
 
         portalForUnderlying[underlying] = portal;
         pTokenForUnderlying[underlying] = pToken;

--- a/contracts/pod/privacy/mocks/MockPodERC20ForPortal.sol
+++ b/contracts/pod/privacy/mocks/MockPodERC20ForPortal.sol
@@ -9,6 +9,8 @@ contract MockPodERC20ForPortal {
     uint256 public lastMintAmount;
     uint256 public lastMintValue;
     uint256 public lastMintCallbackFee;
+    bytes32 public lastMintRequestId;
+    IPodERC20.RequestStatus private _lastMintStatus;
 
     address public lastTransferFrom;
     address public lastTransferTo;
@@ -24,6 +26,8 @@ contract MockPodERC20ForPortal {
 
     bool public burnShouldRevert;
     IPodERC20.RequestStatus private _lastTransferStatus;
+
+    mapping(bytes32 => IPodERC20.RequestStatus) private _requestStatus;
 
     function estimateFee()
         external
@@ -43,6 +47,9 @@ contract MockPodERC20ForPortal {
         lastMintValue = msg.value;
         lastMintCallbackFee = callbackFeeLocalWei;
         requestId = keccak256(abi.encodePacked("mint", to, amount, block.number));
+        lastMintRequestId = requestId;
+        _lastMintStatus = IPodERC20.RequestStatus.Pending;
+        _requestStatus[requestId] = IPodERC20.RequestStatus.Pending;
         return requestId;
     }
 
@@ -63,17 +70,25 @@ contract MockPodERC20ForPortal {
         _lastTransferStatus = IPodERC20.RequestStatus.Pending;
         requestId = keccak256(abi.encodePacked("transfer", from, to, amount, block.number));
         lastTransferRequestId = requestId;
+        _requestStatus[requestId] = IPodERC20.RequestStatus.Pending;
         return requestId;
     }
 
-    function requests(bytes32 requestId) external view returns (IPodERC20.RequestStatus) {
-        if (requestId == lastTransferRequestId && _lastTransferStatus == IPodERC20.RequestStatus.Success) {
-            return IPodERC20.RequestStatus.Success;
+    function requests(bytes32 requestId) external view returns (IPodERC20.RequestRecord memory) {
+        IPodERC20.RequestStatus status = _requestStatus[requestId];
+        if (status == IPodERC20.RequestStatus.None) {
+            if (requestId == lastTransferRequestId) {
+                status = _lastTransferStatus;
+            } else if (requestId == lastMintRequestId) {
+                status = _lastMintStatus;
+            }
         }
-        if (requestId == lastTransferRequestId) {
-            return _lastTransferStatus;
-        }
-        return IPodERC20.RequestStatus.None;
+        return IPodERC20.RequestRecord({
+            status: status,
+            recipientLocked: false,
+            account: address(0),
+            spender: address(0)
+        });
     }
 
     function balanceOf(address) external pure returns (uint256) {
@@ -98,6 +113,45 @@ contract MockPodERC20ForPortal {
 
     function markLastTransferSuccessful() external {
         _lastTransferStatus = IPodERC20.RequestStatus.Success;
+        if (lastTransferRequestId != bytes32(0)) {
+            _requestStatus[lastTransferRequestId] = IPodERC20.RequestStatus.Success;
+        }
+    }
+
+    function markLastTransferFailed() external {
+        _lastTransferStatus = IPodERC20.RequestStatus.Failed;
+        if (lastTransferRequestId != bytes32(0)) {
+            _requestStatus[lastTransferRequestId] = IPodERC20.RequestStatus.Failed;
+        }
+    }
+
+    function markLastTransferSystemFailed() external {
+        _lastTransferStatus = IPodERC20.RequestStatus.SystemFailed;
+        if (lastTransferRequestId != bytes32(0)) {
+            _requestStatus[lastTransferRequestId] = IPodERC20.RequestStatus.SystemFailed;
+        }
+    }
+
+    function markLastMintSuccessful() external {
+        _lastMintStatus = IPodERC20.RequestStatus.Success;
+        if (lastMintRequestId != bytes32(0)) {
+            _requestStatus[lastMintRequestId] = IPodERC20.RequestStatus.Success;
+        }
+    }
+
+    function markLastMintFailed() external {
+        _lastMintStatus = IPodERC20.RequestStatus.SystemFailed;
+        if (lastMintRequestId != bytes32(0)) {
+            _requestStatus[lastMintRequestId] = IPodERC20.RequestStatus.SystemFailed;
+        }
+    }
+
+    /// @dev Simulate app `raise` on mint (not refundable via portal).
+    function markLastMintRaised() external {
+        _lastMintStatus = IPodERC20.RequestStatus.Failed;
+        if (lastMintRequestId != bytes32(0)) {
+            _requestStatus[lastMintRequestId] = IPodERC20.RequestStatus.Failed;
+        }
     }
 
     function setBurnShouldRevert(bool shouldRevert) external {

--- a/contracts/pod/privacy/mocks/MockPrivacyPortalFactory.sol
+++ b/contracts/pod/privacy/mocks/MockPrivacyPortalFactory.sol
@@ -12,8 +12,7 @@ contract MockPrivacyPortalFactory is IPrivacyPortalFactory, Pausable {
     address public immutable feeRecipient;
     address public rescueRecipient;
     address public immutable nativeToken;
-    /// @dev Mutable so tests can transfer factory admin and assert portals pick it up via {isAdmin}.
-    address public admin;
+    address public immutable owner_;
     IPodPriceOracle public priceOracle;
     bytes32 public defaultDepositFeePacked;
     bytes32 public defaultWithdrawFeePacked;
@@ -24,7 +23,7 @@ contract MockPrivacyPortalFactory is IPrivacyPortalFactory, Pausable {
         feeRecipient = feeRecipient_;
         rescueRecipient = feeRecipient_;
         nativeToken = nativeToken_;
-        admin = feeRecipient_;
+        owner_ = feeRecipient_;
         operators[feeRecipient_] = true;
         defaultDepositFeePacked = PrivacyPortalFeeLib.packFeeConfig(0, 0, type(uint128).max);
         defaultWithdrawFeePacked = PrivacyPortalFeeLib.packFeeConfig(0, 0, type(uint128).max);
@@ -35,18 +34,11 @@ contract MockPrivacyPortalFactory is IPrivacyPortalFactory, Pausable {
     }
 
     function owner() external view returns (address) {
-        return admin;
+        return owner_;
     }
 
     function isAdmin(address account) external view returns (bool) {
-        return account == admin;
-    }
-
-    /// @notice Test helper: transfer factory admin (mirrors granting/revoking {DEFAULT_ADMIN_ROLE}).
-    function setAdmin(address account) external {
-        require(msg.sender == admin, "MockPrivacyPortalFactory: only admin");
-        require(account != address(0), "MockPrivacyPortalFactory: zero admin");
-        admin = account;
+        return account == owner_;
     }
 
     function isOperator(address account) external view returns (bool) {

--- a/contracts/pod/privacy/mocks/MockPrivacyPortalFactory.sol
+++ b/contracts/pod/privacy/mocks/MockPrivacyPortalFactory.sol
@@ -8,6 +8,7 @@ import "../PrivacyPortalFeeLib.sol";
 /// @dev Minimal factory for direct PrivacyPortal unit tests (zero portal fees by default).
 contract MockPrivacyPortalFactory is IPrivacyPortalFactory {
     address public immutable feeRecipient;
+    address public rescueRecipient;
     address public immutable nativeToken;
     address public immutable owner_;
     bool public withdrawalsPaused;
@@ -19,10 +20,15 @@ contract MockPrivacyPortalFactory is IPrivacyPortalFactory {
 
     constructor(address feeRecipient_, address nativeToken_) {
         feeRecipient = feeRecipient_;
+        rescueRecipient = feeRecipient_;
         nativeToken = nativeToken_;
         owner_ = feeRecipient_;
         defaultDepositFeePacked = PrivacyPortalFeeLib.packFeeConfig(0, 0, type(uint128).max);
         defaultWithdrawFeePacked = PrivacyPortalFeeLib.packFeeConfig(0, 0, type(uint128).max);
+    }
+
+    function setRescueRecipient(address rescueRecipient_) external {
+        rescueRecipient = rescueRecipient_;
     }
 
     function owner() external view returns (address) {

--- a/contracts/pod/privacy/mocks/MockPrivacyPortalFactory.sol
+++ b/contracts/pod/privacy/mocks/MockPrivacyPortalFactory.sol
@@ -12,7 +12,8 @@ contract MockPrivacyPortalFactory is IPrivacyPortalFactory, Pausable {
     address public immutable feeRecipient;
     address public rescueRecipient;
     address public immutable nativeToken;
-    address public immutable owner_;
+    /// @dev Mutable so tests can transfer factory admin and assert portals pick it up via {isAdmin}.
+    address public admin;
     IPodPriceOracle public priceOracle;
     bytes32 public defaultDepositFeePacked;
     bytes32 public defaultWithdrawFeePacked;
@@ -23,7 +24,7 @@ contract MockPrivacyPortalFactory is IPrivacyPortalFactory, Pausable {
         feeRecipient = feeRecipient_;
         rescueRecipient = feeRecipient_;
         nativeToken = nativeToken_;
-        owner_ = feeRecipient_;
+        admin = feeRecipient_;
         operators[feeRecipient_] = true;
         defaultDepositFeePacked = PrivacyPortalFeeLib.packFeeConfig(0, 0, type(uint128).max);
         defaultWithdrawFeePacked = PrivacyPortalFeeLib.packFeeConfig(0, 0, type(uint128).max);
@@ -34,7 +35,18 @@ contract MockPrivacyPortalFactory is IPrivacyPortalFactory, Pausable {
     }
 
     function owner() external view returns (address) {
-        return owner_;
+        return admin;
+    }
+
+    function isAdmin(address account) external view returns (bool) {
+        return account == admin;
+    }
+
+    /// @notice Test helper: transfer factory admin (mirrors granting/revoking {DEFAULT_ADMIN_ROLE}).
+    function setAdmin(address account) external {
+        require(msg.sender == admin, "MockPrivacyPortalFactory: only admin");
+        require(account != address(0), "MockPrivacyPortalFactory: zero admin");
+        admin = account;
     }
 
     function isOperator(address account) external view returns (bool) {

--- a/contracts/pod/privacy/mocks/MockPrivacyPortalFactory.sol
+++ b/contracts/pod/privacy/mocks/MockPrivacyPortalFactory.sol
@@ -1,28 +1,30 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
+import "@openzeppelin/contracts/utils/Pausable.sol";
+
 import "../IPodPriceOracle.sol";
 import "../IPrivacyPortalFactory.sol";
 import "../PrivacyPortalFeeLib.sol";
 
 /// @dev Minimal factory for direct PrivacyPortal unit tests (zero portal fees by default).
-contract MockPrivacyPortalFactory is IPrivacyPortalFactory {
+contract MockPrivacyPortalFactory is IPrivacyPortalFactory, Pausable {
     address public immutable feeRecipient;
     address public rescueRecipient;
     address public immutable nativeToken;
     address public immutable owner_;
-    bool public withdrawalsPaused;
-    bool public depositsPaused;
     IPodPriceOracle public priceOracle;
     bytes32 public defaultDepositFeePacked;
     bytes32 public defaultWithdrawFeePacked;
     mapping(address => bool) public blacklisted;
+    mapping(address => bool) public operators;
 
     constructor(address feeRecipient_, address nativeToken_) {
         feeRecipient = feeRecipient_;
         rescueRecipient = feeRecipient_;
         nativeToken = nativeToken_;
         owner_ = feeRecipient_;
+        operators[feeRecipient_] = true;
         defaultDepositFeePacked = PrivacyPortalFeeLib.packFeeConfig(0, 0, type(uint128).max);
         defaultWithdrawFeePacked = PrivacyPortalFeeLib.packFeeConfig(0, 0, type(uint128).max);
     }
@@ -35,16 +37,40 @@ contract MockPrivacyPortalFactory is IPrivacyPortalFactory {
         return owner_;
     }
 
-    function setWithdrawalsPaused(bool paused) external {
-        withdrawalsPaused = paused;
+    function isOperator(address account) external view returns (bool) {
+        return operators[account];
     }
 
-    function setDepositsPaused(bool paused) external {
-        depositsPaused = paused;
+    function setOperator(address account, bool allowed) external {
+        operators[account] = allowed;
+    }
+
+    function pause() external {
+        _pause();
+    }
+
+    function unpause() external {
+        _unpause();
+    }
+
+    function depositsPaused() external view returns (bool) {
+        return paused();
+    }
+
+    function withdrawalsPaused() external view returns (bool) {
+        return paused();
     }
 
     function setBlacklisted(address account, bool blocked) external {
         blacklisted[account] = blocked;
+    }
+
+    function setDefaultDepositFee(uint256 fixedFee, uint256 percentageBps, uint256 maxFee) external {
+        defaultDepositFeePacked = PrivacyPortalFeeLib.packFeeConfig(fixedFee, percentageBps, maxFee);
+    }
+
+    function setDefaultWithdrawFee(uint256 fixedFee, uint256 percentageBps, uint256 maxFee) external {
+        defaultWithdrawFeePacked = PrivacyPortalFeeLib.packFeeConfig(fixedFee, percentageBps, maxFee);
     }
 
     function estimateDepositPortalFee(address, uint256, uint8)

--- a/contracts/pod/token/perc20/IPodERC20.sol
+++ b/contracts/pod/token/perc20/IPodERC20.sol
@@ -14,7 +14,22 @@ interface IPodERC20 {
         None,
         Pending,
         Success,
-        Failed
+        /// @notice App `raise` / Exception path. Not eligible for portal deposit refund.
+        Failed,
+        /// @notice Inbox system error (encode / `validateCiphertext`). Deposit refundable via portal.
+        SystemFailed
+    }
+
+    /// @notice Status plus lock metadata for an async inbox request.
+    /// @dev Transfer/burn: `account` = locked party, `spender` = 0, `recipientLocked` = false.
+    ///      Mint: `account` = recipient, `spender` = 0, `recipientLocked` = true.
+    ///      Approval: `account` = owner, `spender` = spender, `recipientLocked` unused.
+    ///      Sync: no lock (`account`/`spender` stay 0).
+    struct RequestRecord {
+        RequestStatus status;
+        bool recipientLocked;
+        address account;
+        address spender;
     }
 
     /// @notice Allowance represented twice: re-encrypted for the owner and for the spender so each party can decrypt their view.
@@ -89,8 +104,8 @@ interface IPodERC20 {
      */
     function totalSupply() external view returns (uint256);
 
-    /// @notice Status of an async request submitted by this token.
-    function requests(bytes32 requestId) external view returns (RequestStatus);
+    /// @notice Async request record (status + lock metadata) for a request submitted by this token.
+    function requests(bytes32 requestId) external view returns (RequestRecord memory);
 
     /**
      * @notice Estimate the native fee split used by auto-fee two-way token methods.
@@ -277,4 +292,7 @@ interface IPodERC20 {
      * @dev **Gotcha:** large account lists mean heavy MPC work and gas on COTI; empty list may fail on the COTI side.
      */
     function syncBalances(address[] calldata accounts, uint256 callbackFeeLocalWei) external payable returns (bytes32 requestId);
+
+    /// @notice Owner-only: set inbox when `inbox_ != address(0)`; always updates COTI peer. {cotiChainId} is fixed at init.
+    function configure(address inbox_, address cotiSideContract_) external;
 }

--- a/contracts/pod/token/perc20/PodERC20.sol
+++ b/contracts/pod/token/perc20/PodERC20.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.20;
 import "../../InboxUser.sol";
 import "../../fee/IInboxFeeManager.sol";
 import "../../mpccodec/MpcAbiCodec.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
 import "./IPodERC20.sol";
@@ -14,7 +15,8 @@ import "../erc7984/PodErc7984Mixin.sol";
 /// @notice PoD-side private ERC-20: ciphertext cache and inbox-mediated async moves; COTI holds authoritative garbled state via {IPodErc20CotiSide}.
 /// @dev Callbacks only from `inbox` when the remote peer matches (`cotiChainId`, `cotiSideContract`). Public-amount methods expose amounts in calldata and logs; use encrypted `itUint256` entry points for privacy-sensitive flows.
 ///      {_sendPodTwoWay} is `nonReentrant` so a compromised inbox/oracle cannot re-enter before pending locks are written.
-contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTransient {
+///      Owner may rotate inbox / COTI peer via {configure}.
+contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTransient, Ownable {
     using MpcAbiCodec for MpcAbiCodec.MpcMethodCallContext;
 
     // --- State variables ---
@@ -49,7 +51,9 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
     mapping(address => mapping(address => bytes32)) private _pendingApprovalRequestIds;
     /// @dev Optional `transferAndCall` payload keyed by inbox `sourceRequestId`, cleared after callback.
     mapping(bytes32 => bytes) private _requestCallbacks;
-    mapping(bytes32 => IPodERC20.RequestStatus) public requests;
+    /// @dev Status plus lock metadata (for system-error clear when payload has no accounts).
+    ///      See {IPodERC20.RequestRecord}.
+    mapping(bytes32 => IPodERC20.RequestRecord) private _requests;
     mapping(bytes32 => bytes) public failedRequests;
     /// @dev Monotonic nonce from COTI; stale callbacks do not overwrite newer balances.
     mapping(address => uint256) public balanceNonces;
@@ -66,6 +70,8 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
     event SyncBalancesFailed(bytes32 requestId, bytes errorMsg);
     /// @notice Async balance-sync request was submitted for accounts.
     event SyncBalancesRequested(address[] accounts, bytes32 requestId);
+    /// @notice Inbox delivered a system error (encode/validateCiphertext); COTI app never ran; not retryable.
+    event SystemRequestFailed(bytes32 indexed requestId, uint64 errorCode, bytes errorMessage);
 
     // --- Errors ---
 
@@ -75,6 +81,12 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
     error ApprovalAlreadyPending(address owner, address spender, bytes32 requestId);
     /// @notice Inbox caller was not the configured COTI-side peer.
     error OnlyCotiSideContract(uint256 remoteChainId, address remoteContract);
+    /// @notice Error callback invoked outside a system-error or app-raise delivery context.
+    error UnexpectedErrorContext();
+    /// @notice Error delivery has no linked source request id.
+    error ErrorRequestNotLinked();
+    /// @notice Linked source request is not Pending (already settled or unknown).
+    error ErrorRequestNotPending(bytes32 requestId, IPodERC20.RequestStatus status);
     /// @notice Thrown by the default {_checkMinter} hook; subclasses (e.g. {PodErc20Mintable}) can override to allow minting.
     error MintNotAllowed(address caller);
     /// @notice Clone storage was already initialized.
@@ -101,13 +113,28 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
         address _cotiSideContract,
         string memory _name,
         string memory _symbol
-    ) {
+    ) Ownable(address(1)) {
         _initializePodERC20(_cotiChainId, _inbox, _cotiSideContract, _name, _symbol);
+        // Direct deploys take ownership here. Factory clones never run this constructor; {PodErc20MintableInitializable.initialize} sets the owner.
+        _transferOwnership(msg.sender);
     }
 
     /// @notice Accept native funds used to pay inbox fees for async pToken operations.
     /// @dev `_sendPodTwoWay` may spend existing contract balance, so operational tooling can pre-fund this token for auto-fee flows.
     receive() external payable {}
+
+    /// @notice Owner-only: set inbox when `inbox_ != address(0)`; always updates COTI peer. {cotiChainId} is fixed at init.
+    /// @param inbox_ New inbox address, or zero to leave the existing inbox unchanged.
+    /// @param cotiSideContract_ New COTI-side ledger / MPC peer address.
+    function configure(address inbox_, address cotiSideContract_) external onlyOwner {
+        if (cotiSideContract_ == address(0)) {
+            revert PodERC20InvalidInitialization();
+        }
+        if (inbox_ != address(0)) {
+            setInbox(inbox_);
+        }
+        cotiSideContract = cotiSideContract_;
+    }
 
     // --- External: mutating (user / admin) ---
 
@@ -287,17 +314,14 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
             ctUint256 memory receiverValue,
             uint256 nonce
         ) = abi.decode(data, (address, ctUint256, ctUint256, address, ctUint256, ctUint256, uint256));
+        _clearPendingByRequestId(sourceRequestId);
         if (from != address(0)) {
-            _pendingTransferRequestIds[from] = bytes32(0);
             if (balanceNonces[from] < nonce) {
                 _balances[from] = newBalanceFrom;
                 balanceNonces[from] = nonce;
             }
         }
         if (to != address(0)) {
-            if (from == address(0)) {
-                _pendingTransferRequestIds[to] = bytes32(0);
-            }
             if (balanceNonces[to] < nonce) {
                 _balances[to] = newBalanceTo;
                 balanceNonces[to] = nonce;
@@ -331,7 +355,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
             data,
             (address, ctUint256, address, ctUint256)
         );
-        _pendingApprovalRequestIds[owner][spender] = bytes32(0);
+        _clearPendingByRequestId(sourceRequestId);
         _allowance[owner][spender] = Allowance({spenderCiphertext: spenderAmount, ownerCiphertext: ownerAmount});
         emit Approval(owner, spender, ownerAmount, spenderAmount);
     }
@@ -362,54 +386,59 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
     }
 
     // --- External: inbox callbacks (errors) ---
+    //
+    // Pattern for `errorSelector(bytes data)` — system and app `raise` share this entrypoint:
+    //   1. Auth: onlyInbox; _errorCallbackContext() reverts unless SystemError/Exception + Pending link.
+    //   2. Branch on inboxErrorType():
+    //        SystemError → {IInbox.ErrorData}: abi.encode(uint64 code, bytes message)
+    //        Exception   → dApp raise layout for this selector
 
-    /**
-     * @notice Clears pending transfer state and records `failedRequests` for this `sourceRequestId`.
-     * @dev Transfers and burns lock only `from`; mints lock only `to` (`from == address(0)` in the error payload).
-     */
+    /// @notice Clears pending transfer/mint/burn state after COTI failure.
     function transferError(bytes memory data) external onlyInbox {
-        (uint256 remoteChainId, address remoteContract) = inbox.inboxMsgSender();
-        if (remoteChainId != cotiChainId || remoteContract != cotiSideContract) {
-            revert OnlyCotiSideContract(remoteChainId, remoteContract);
+        (IInbox.InboxErrorType errType, bytes32 sourceRequestId) = _errorCallbackContext();
+        if (errType == IInbox.InboxErrorType.SystemError) {
+            _handleSystemError(sourceRequestId, data);
+            return;
         }
         (address from, address to, bytes memory errorMsg) = abi.decode(data, (address, address, bytes));
-        bytes32 sourceRequestId = inbox.inboxSourceRequestId();
         _setRequestStatus(sourceRequestId, IPodERC20.RequestStatus.Failed);
         failedRequests[sourceRequestId] = errorMsg;
-        if (from != address(0)) {
-            _pendingTransferRequestIds[from] = bytes32(0);
-        } else if (to != address(0)) {
-            _pendingTransferRequestIds[to] = bytes32(0);
-        }
+        _clearPendingByRequestId(sourceRequestId);
         emit TransferFailed(from, to, errorMsg);
     }
 
-    /// @notice Clears pending approval and surfaces COTI error bytes to listeners and {failedRequests}.
+    /// @notice Clears pending approval state after COTI failure.
     function approveError(bytes memory data) external onlyInbox {
-        (uint256 remoteChainId, address remoteContract) = inbox.inboxMsgSender();
-        if (remoteChainId != cotiChainId || remoteContract != cotiSideContract) {
-            revert OnlyCotiSideContract(remoteChainId, remoteContract);
+        (IInbox.InboxErrorType errType, bytes32 sourceRequestId) = _errorCallbackContext();
+        if (errType == IInbox.InboxErrorType.SystemError) {
+            _handleSystemError(sourceRequestId, data);
+            return;
         }
         (address owner, address spender, bytes memory errorMsg) = abi.decode(data, (address, address, bytes));
-        bytes32 sourceRequestId = inbox.inboxSourceRequestId();
         _setRequestStatus(sourceRequestId, IPodERC20.RequestStatus.Failed);
         failedRequests[sourceRequestId] = errorMsg;
-        _pendingApprovalRequestIds[owner][spender] = bytes32(0);
+        _clearPendingByRequestId(sourceRequestId);
         emit ApprovalFailed(owner, spender, errorMsg);
     }
 
-    /// @notice `syncBalances` failed on COTI; `data` is forwarded into {SyncBalancesFailed} for debugging.
+    /// @notice Marks sync failed after COTI failure.
     function syncBalancesError(bytes memory data) external onlyInbox {
-        (uint256 remoteChainId, address remoteContract) = inbox.inboxMsgSender();
-        if (remoteChainId != cotiChainId || remoteContract != cotiSideContract) {
-            revert OnlyCotiSideContract(remoteChainId, remoteContract);
+        (IInbox.InboxErrorType errType, bytes32 sourceRequestId) = _errorCallbackContext();
+        if (errType == IInbox.InboxErrorType.SystemError) {
+            _handleSystemError(sourceRequestId, data);
+            return;
         }
-        bytes32 sourceRequestId = inbox.inboxSourceRequestId();
         _setRequestStatus(sourceRequestId, IPodERC20.RequestStatus.Failed);
+        failedRequests[sourceRequestId] = data;
         emit SyncBalancesFailed(sourceRequestId, data);
     }
 
     // --- External: views ---
+
+    /// @inheritdoc IPodERC20
+    function requests(bytes32 requestId) external view returns (IPodERC20.RequestRecord memory) {
+        return _requests[requestId];
+    }
 
     /// @inheritdoc IPodERC20
     function balanceOf(address account) external view returns (ctUint256 memory) {
@@ -524,8 +553,90 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
     }
 
     function _setRequestStatus(bytes32 requestId, IPodERC20.RequestStatus status) internal {
-        requests[requestId] = status;
+        _requests[requestId].status = status;
         emit RequestStatusUpdated(requestId, status);
+    }
+
+    /// @dev Lock a single account for transfer/burn (`recipientLocked=false`) or mint (`recipientLocked=true`).
+    function _lockTransferPending(bytes32 requestId, address locked, bool recipientLocked) internal {
+        _pendingTransferRequestIds[locked] = requestId;
+        IPodERC20.RequestRecord storage rec = _requests[requestId];
+        rec.account = locked;
+        rec.spender = address(0);
+        rec.recipientLocked = recipientLocked;
+    }
+
+    function _lockApprovalPending(bytes32 requestId, address owner, address spender) internal {
+        _pendingApprovalRequestIds[owner][spender] = requestId;
+        IPodERC20.RequestRecord storage rec = _requests[requestId];
+        rec.account = owner;
+        rec.spender = spender;
+        rec.recipientLocked = false;
+    }
+
+    function _clearPendingByRequestId(bytes32 requestId) internal {
+        IPodERC20.RequestRecord storage rec = _requests[requestId];
+        if (rec.spender != address(0)) {
+            if (_pendingApprovalRequestIds[rec.account][rec.spender] == requestId) {
+                _pendingApprovalRequestIds[rec.account][rec.spender] = bytes32(0);
+            }
+        } else if (rec.account != address(0)) {
+            if (_pendingTransferRequestIds[rec.account] == requestId) {
+                _pendingTransferRequestIds[rec.account] = bytes32(0);
+            }
+        }
+        rec.account = address(0);
+        rec.spender = address(0);
+        rec.recipientLocked = false;
+    }
+
+    /// @dev Apply Inbox system-error payload: {IInbox.ErrorData} = abi.encode(uint64 code, bytes message).
+    function _handleSystemError(bytes32 sourceRequestId, bytes memory data) internal {
+        (uint64 errorCode, bytes memory errorMessage) = abi.decode(data, (uint64, bytes));
+        IPodERC20.RequestRecord storage rec = _requests[sourceRequestId];
+        address account = rec.account;
+        address spender = rec.spender;
+        bool recipientLocked = rec.recipientLocked;
+        _setRequestStatus(sourceRequestId, IPodERC20.RequestStatus.SystemFailed);
+        failedRequests[sourceRequestId] = data;
+        _clearPendingByRequestId(sourceRequestId);
+        emit SystemRequestFailed(sourceRequestId, errorCode, errorMessage);
+        if (spender != address(0)) {
+            emit ApprovalFailed(account, spender, errorMessage);
+        } else if (account != address(0) || recipientLocked) {
+            emit TransferFailed(
+                recipientLocked ? address(0) : account,
+                recipientLocked ? account : address(0),
+                errorMessage
+            );
+        } else {
+            emit SyncBalancesFailed(sourceRequestId, errorMessage);
+        }
+    }
+
+    /// @dev Validates error delivery context. Reverts on every invalid case; never returns a zero request id.
+    function _errorCallbackContext()
+        internal
+        view
+        returns (IInbox.InboxErrorType errType, bytes32 sourceRequestId)
+    {
+        errType = inbox.inboxErrorType();
+        if (errType == IInbox.InboxErrorType.NotErrorContext) {
+            revert UnexpectedErrorContext();
+        }
+        if (errType != IInbox.InboxErrorType.SystemError && errType != IInbox.InboxErrorType.Exception) {
+            revert UnexpectedErrorContext();
+        }
+
+        sourceRequestId = inbox.inboxSourceRequestId();
+        if (sourceRequestId == bytes32(0)) {
+            revert ErrorRequestNotLinked();
+        }
+
+        IPodERC20.RequestStatus status = _requests[sourceRequestId].status;
+        if (status != IPodERC20.RequestStatus.Pending) {
+            revert ErrorRequestNotPending(sourceRequestId, status);
+        }
     }
 
     function _approve(address owner, address spender, itUint256 calldata value, uint256 totalValueWei, uint256 callbackFeeLocalWei) internal returns (bytes32 requestId) {
@@ -546,7 +657,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
             PodERC20.approveError.selector
         );
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
-        _pendingApprovalRequestIds[owner][spender] = requestId;
+        _lockApprovalPending(requestId, owner, spender);
         emit ApprovalRequestSubmitted(owner, spender, requestId);
     }
 
@@ -569,7 +680,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
         );
 
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
-        _pendingTransferRequestIds[from] = requestId;
+        _lockTransferPending(requestId, from, false);
         emit TransferRequestSubmitted(from, address(0), requestId);
     }
 
@@ -602,7 +713,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
             PodERC20.transferError.selector
         );
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
-        _pendingTransferRequestIds[from] = requestId;
+        _lockTransferPending(requestId, from, false);
         emit TransferRequestSubmitted(msg.sender, to, requestId);
     }
 
@@ -634,7 +745,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
             PodERC20.transferError.selector
         );
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
-        _pendingTransferRequestIds[from] = requestId;
+        _lockTransferPending(requestId, from, false);
         emit TransferRequestSubmitted(from, to, requestId);
     }
 
@@ -716,7 +827,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
             PodERC20.transferError.selector
         );
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
-        _pendingTransferRequestIds[to] = requestId;
+        _lockTransferPending(requestId, to, true);
         emit TransferRequestSubmitted(address(0), to, requestId);
     }
 
@@ -747,7 +858,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
             PodERC20.transferError.selector
         );
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
-        _pendingTransferRequestIds[from] = requestId;
+        _lockTransferPending(requestId, from, false);
         emit TransferRequestSubmitted(msg.sender, to, requestId);
     }
 
@@ -779,7 +890,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
             PodERC20.transferError.selector
         );
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
-        _pendingTransferRequestIds[from] = requestId;
+        _lockTransferPending(requestId, from, false);
         emit TransferRequestSubmitted(from, to, requestId);
     }
 
@@ -811,7 +922,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
             PodERC20.transferError.selector
         );
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
-        _pendingTransferRequestIds[from] = requestId;
+        _lockTransferPending(requestId, from, false);
         emit TransferRequestSubmitted(from, to, requestId);
     }
 
@@ -841,7 +952,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
             PodERC20.approveError.selector
         );
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
-        _pendingApprovalRequestIds[owner][spender] = requestId;
+        _lockApprovalPending(requestId, owner, spender);
         emit ApprovalRequestSubmitted(owner, spender, requestId);
     }
 
@@ -869,7 +980,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
             PodERC20.transferError.selector
         );
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
-        _pendingTransferRequestIds[from] = requestId;
+        _lockTransferPending(requestId, from, false);
         emit TransferRequestSubmitted(from, address(0), requestId);
     }
 
@@ -897,7 +1008,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTrans
             PodERC20.transferError.selector
         );
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Pending);
-        _pendingTransferRequestIds[to] = requestId;
+        _lockTransferPending(requestId, to, true);
         emit TransferRequestSubmitted(address(0), to, requestId);
     }
 

--- a/contracts/pod/token/perc20/PodERC20.sol
+++ b/contracts/pod/token/perc20/PodERC20.sol
@@ -6,7 +6,7 @@ import "../../fee/IInboxFeeManager.sol";
 import "../../mpccodec/MpcAbiCodec.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
+import "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 import "./IPodERC20.sol";
 import "./cotiside/IPodErc20CotiSide.sol";
 import "../erc7984/PodErc7984Mixin.sol";
@@ -15,8 +15,9 @@ import "../erc7984/PodErc7984Mixin.sol";
 /// @notice PoD-side private ERC-20: ciphertext cache and inbox-mediated async moves; COTI holds authoritative garbled state via {IPodErc20CotiSide}.
 /// @dev Callbacks only from `inbox` when the remote peer matches (`cotiChainId`, `cotiSideContract`). Public-amount methods expose amounts in calldata and logs; use encrypted `itUint256` entry points for privacy-sensitive flows.
 ///      {_sendPodTwoWay} is `nonReentrant` so a compromised inbox/oracle cannot re-enter before pending locks are written.
+///      Uses storage `ReentrancyGuard` (not transient) so the whole tree can compile for Paris — COTI rejects Shanghai `PUSH0`.
 ///      Owner may rotate inbox / COTI peer via {configure}.
-contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuardTransient, Ownable {
+contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Ownable {
     using MpcAbiCodec for MpcAbiCodec.MpcMethodCallContext;
 
     // --- State variables ---

--- a/contracts/pod/token/perc20/PodErc20MintableInitializable.sol
+++ b/contracts/pod/token/perc20/PodErc20MintableInitializable.sol
@@ -6,8 +6,8 @@ import "./PodErc20Mintable.sol";
 
 /// @title PodErc20MintableInitializable
 /// @notice Clone-friendly {PodErc20Mintable}; the implementation constructor locks the implementation instance.
-/// @dev Split deploy-then-initialize is unsafe: an attacker can front-run `initialize` on an uninitialized clone.
-///      Use {PrivacyPortalFactory.createPortal} or another single-transaction clone+init path.
+/// @dev Usual deploy path is {PrivacyPortalFactory.createPortal} (clone + initialize in one tx).
+///      Split deploy-then-initialize is unsafe: an attacker can front-run `initialize` on an uninitialized clone.
 contract PodErc20MintableInitializable is PodErc20Mintable, Initializable {
     /// @notice Lock the implementation instance with placeholder values.
     constructor() PodErc20Mintable(address(1), 1, address(1), address(1), "IMPLEMENTATION", "IMPL") {
@@ -15,7 +15,8 @@ contract PodErc20MintableInitializable is PodErc20Mintable, Initializable {
     }
 
     /// @notice Initialize a mintable source-chain pToken clone.
-    /// @param _minter Address allowed to mint.
+    /// @param _minter Address allowed to mint (the paired {PrivacyPortal}).
+    /// @param _owner Ownable admin allowed to {configure} inbox / COTI peer; factory passes `address(this)`.
     /// @param _cotiChainId COTI chain id for remote MPC execution.
     /// @param _inbox Source-chain inbox.
     /// @param _cotiSideContract COTI-side pToken ledger.
@@ -24,6 +25,7 @@ contract PodErc20MintableInitializable is PodErc20Mintable, Initializable {
     /// @param _decimals Token decimals.
     function initialize(
         address _minter,
+        address _owner,
         uint256 _cotiChainId,
         address _inbox,
         address _cotiSideContract,
@@ -31,6 +33,10 @@ contract PodErc20MintableInitializable is PodErc20Mintable, Initializable {
         string memory _symbol,
         uint8 _decimals
     ) external initializer {
+        if (_owner == address(0)) {
+            revert PodERC20InvalidInitialization();
+        }
         _initializePodErc20Mintable(_minter, _cotiChainId, _inbox, _cotiSideContract, _name, _symbol, _decimals);
+        _transferOwnership(_owner);
     }
 }

--- a/contracts/pod/token/perc20/cotiside/PodErc20CotiMother.sol
+++ b/contracts/pod/token/perc20/cotiside/PodErc20CotiMother.sol
@@ -155,6 +155,15 @@ contract PodErc20CotiMother is IPodErc20CotiSide, InboxUser, Ownable {
         emit AllowedFactoryUpdated(sourceChainId, factory, allowed);
     }
 
+    /// @notice Owner-only: rotate the COTI-side inbox used for remote pToken / factory messages.
+    function configure(address inbox_) external onlyOwner {
+        if (inbox_ == address(0)) {
+            revert InvalidAddress();
+        }
+        setInbox(inbox_);
+        emit CotiMotherInitialized(inbox_, owner());
+    }
+
     /// @inheritdoc IPodErc20CotiSide
     /// @dev Not supported on the unified mother ledger; mint via inbox {mintPublic} from the paired pToken minter.
     function ownerMint(address, uint256) external pure override {

--- a/test/pod/privacy/PrivacyPortal.access.test.ts
+++ b/test/pod/privacy/PrivacyPortal.access.test.ts
@@ -330,13 +330,10 @@ describe("PrivacyPortal access controls", function () {
             expect(await factory.owner()).to.equal(owner.address)
         })
 
-        it("lets admin set fee and rescue recipients", async function () {
+        it("lets admin set rescue recipient (fee recipient is immutable)", async function () {
             const { owner, operator, other, factory } = await deployFactoryFixture()
 
-            await expect(factory.connect(owner).setFeeRecipient(other.address))
-                .to.emit(factory, "FeeRecipientUpdated")
-                .withArgs(owner.address, other.address)
-            expect(await factory.feeRecipient()).to.equal(other.address)
+            expect(await factory.feeRecipient()).to.equal(owner.address)
 
             await expect(factory.connect(owner).setRescueRecipient(operator.address))
                 .to.emit(factory, "RescueRecipientUpdated")
@@ -539,16 +536,15 @@ describe("PrivacyPortal access controls", function () {
             expect(withdraw.maxFee).to.equal(400)
         })
 
-        it("updates fee and rescue recipients as admin only", async function () {
-            const { owner, operator, other, factory } = await deployFactoryFixture()
+        it("updates rescue recipient as admin only; fee recipient is immutable", async function () {
+            const { owner, operator, factory } = await deployFactoryFixture()
 
-            await factory.connect(owner).setFeeRecipient(other.address)
+            expect(await factory.feeRecipient()).to.equal(owner.address)
             await factory.connect(owner).setRescueRecipient(operator.address)
-            expect(await factory.feeRecipient()).to.equal(other.address)
             expect(await factory.rescueRecipient()).to.equal(operator.address)
 
             await expect(
-                factory.connect(operator).setFeeRecipient(owner.address)
+                factory.connect(operator).setRescueRecipient(owner.address)
             ).to.be.revertedWithCustomError(factory, "AccessControlUnauthorizedAccount")
         })
 

--- a/test/pod/privacy/PrivacyPortal.access.test.ts
+++ b/test/pod/privacy/PrivacyPortal.access.test.ts
@@ -32,7 +32,6 @@ describe("PrivacyPortal access controls", function () {
         const portal = PortalImpl.attach(portalAddress) as Awaited<ReturnType<typeof PortalImpl.deploy>>
 
         await portal.initialize(
-            owner.address,
             await underlying.getAddress(),
             await pToken.getAddress(),
             6,
@@ -119,7 +118,7 @@ describe("PrivacyPortal access controls", function () {
         const portalAddress = await cloneHelper.lastClone()
         const portal = PortalImpl.attach(portalAddress) as Awaited<ReturnType<typeof PortalImpl.deploy>>
 
-        await portal.initialize(owner.address, wethAddress, await pToken.getAddress(), 18, true, await factory.getAddress())
+        await portal.initialize(wethAddress, await pToken.getAddress(), 18, true, await factory.getAddress())
 
         const depositAmount = parseEther("1")
 
@@ -176,12 +175,12 @@ describe("PrivacyPortal access controls", function () {
             ).to.be.revertedWithCustomError(portal, "WithdrawExceedsMaximum")
         })
 
-        it("allows only the portal owner to update limits", async function () {
+        it("allows only the factory admin to update limits", async function () {
             const { owner, user, portal } = await deployPortalFixture()
 
             await expect(
                 portal.connect(user).setLimits(1, 2, 3, 4)
-            ).to.be.revertedWithCustomError(portal, "OwnableUnauthorizedAccount")
+            ).to.be.revertedWithCustomError(portal, "OnlyFactoryAdmin")
 
             await expect(portal.connect(owner).setLimits(1, 2, 3, 4)).to.not.be.reverted
         })
@@ -355,6 +354,407 @@ describe("PrivacyPortal access controls", function () {
 
             await factory.connect(owner).grantRole(adminRole, operator.address)
             expect(await factory.owner()).to.equal(owner.address)
+        })
+    })
+
+    describe("pause (instance then factory)", function () {
+        it("lets portal owner pause only that instance", async function () {
+            const { owner, user, portal, underlying, depositAmount } = await deployPortalFixture()
+
+            await portal.connect(owner).pause()
+            expect(await portal.paused()).to.equal(true)
+
+            await underlying.connect(user).approve(await portal.getAddress(), depositAmount)
+            await expect(
+                portal.connect(user).deposit(user.address, depositAmount, 0, 100, { value: 1000 })
+            ).to.be.revertedWithCustomError(portal, "DepositsPaused")
+
+            await expect(
+                portal.connect(user).requestWithdrawWithPermit(
+                    user.address,
+                    1,
+                    0,
+                    1000,
+                    100,
+                    999_999_999,
+                    27,
+                    hre.ethers.ZeroHash,
+                    hre.ethers.ZeroHash,
+                    { value: 1000 }
+                )
+            ).to.be.revertedWithCustomError(portal, "WithdrawalsPaused")
+        })
+
+        it("rejects non-admin portal pause", async function () {
+            const { user, portal } = await deployPortalFixture()
+            await expect(portal.connect(user).pause()).to.be.revertedWithCustomError(
+                portal,
+                "OnlyFactoryAdmin"
+            )
+        })
+
+        it("factory pause pauses deposits and withdrawals on portals", async function () {
+            const { owner, user, portal, underlying, factory, depositAmount } =
+                await deployPortalFixture()
+
+            await factory.connect(owner).pause()
+            expect(await factory.paused()).to.equal(true)
+            expect(await factory.depositsPaused()).to.equal(true)
+            expect(await factory.withdrawalsPaused()).to.equal(true)
+
+            await underlying.connect(user).approve(await portal.getAddress(), depositAmount)
+            await expect(
+                portal.connect(user).deposit(user.address, depositAmount, 0, 100, { value: 1000 })
+            ).to.be.revertedWithCustomError(portal, "DepositsPaused")
+
+            await expect(
+                portal.connect(user).requestWithdrawWithPermit(
+                    user.address,
+                    1,
+                    0,
+                    1000,
+                    100,
+                    999_999_999,
+                    27,
+                    hre.ethers.ZeroHash,
+                    hre.ethers.ZeroHash,
+                    { value: 1000 }
+                )
+            ).to.be.revertedWithCustomError(portal, "WithdrawalsPaused")
+        })
+
+        it("rejects non-admin factory pause", async function () {
+            const { operator, factory } = await deployFactoryFixture()
+            await expect(factory.connect(operator).pause()).to.be.revertedWithCustomError(
+                factory,
+                "AccessControlUnauthorizedAccount"
+            )
+        })
+
+        it("unpausing the instance restores entry points when factory is not paused", async function () {
+            const { owner, user, portal, underlying, depositAmount } = await deployPortalFixture()
+
+            await portal.connect(owner).pause()
+            await portal.connect(owner).unpause()
+            expect(await portal.paused()).to.equal(false)
+
+            await underlying.connect(user).approve(await portal.getAddress(), depositAmount)
+            await expect(
+                portal.connect(user).deposit(user.address, depositAmount, 0, 100, { value: 1000 })
+            ).to.not.be.reverted
+        })
+
+        it("instance unpause does not clear factory pause", async function () {
+            const { owner, user, portal, underlying, factory, depositAmount } =
+                await deployPortalFixture()
+
+            await factory.connect(owner).pause()
+            await portal.connect(owner).pause()
+            await portal.connect(owner).unpause()
+
+            await underlying.connect(user).approve(await portal.getAddress(), depositAmount)
+            await expect(
+                portal.connect(user).deposit(user.address, depositAmount, 0, 100, { value: 1000 })
+            ).to.be.revertedWithCustomError(portal, "DepositsPaused")
+        })
+    })
+
+    describe("portal fee overrides", function () {
+        it("requires factory operator for portal fee overrides", async function () {
+            const { owner, user, operator, portal, factory } = await deployPortalFixture()
+
+            await expect(
+                portal.connect(user).setDepositFee(1, 0, 100)
+            ).to.be.revertedWithCustomError(portal, "OnlyFactoryOperator")
+
+            await factory.connect(owner).setOperator(operator.address, true)
+            await expect(portal.connect(operator).setDepositFee(1, 0, 100)).to.not.be.reverted
+
+            const config = await portal.getFeeConfig(true)
+            expect(config.fixedFee).to.equal(1)
+            expect(config.maxFee).to.equal(100)
+        })
+
+        it("overrides deposit and withdraw fees and clears back to factory defaults", async function () {
+            const { owner, operator, portal, factory } = await deployPortalFixture()
+            await factory.connect(owner).setDefaultDepositFee(5, 0, 50)
+            await factory.connect(owner).setDefaultWithdrawFee(7, 0, 70)
+            await factory.connect(owner).setOperator(operator.address, true)
+
+            await portal.connect(operator).setDepositFee(11, 0, 110)
+            await portal.connect(operator).setWithdrawFee(13, 0, 130)
+
+            expect((await portal.getFeeConfig(true)).fixedFee).to.equal(11)
+            expect((await portal.getFeeConfig(false)).fixedFee).to.equal(13)
+
+            const [depositOverride, depositSet] = await portal.getFeeConfigOverride(true)
+            expect(depositSet).to.equal(true)
+            expect(depositOverride.fixedFee).to.equal(11)
+
+            await portal.connect(operator).clearDepositFeeOverride()
+            await portal.connect(operator).clearWithdrawFeeOverride()
+
+            expect((await portal.getFeeConfig(true)).fixedFee).to.equal(5)
+            expect((await portal.getFeeConfig(false)).fixedFee).to.equal(7)
+            const [, cleared] = await portal.getFeeConfigOverride(true)
+            expect(cleared).to.equal(false)
+        })
+
+        it("lets factory operator toggle soft deposit enable", async function () {
+            const { owner, user, operator, portal, underlying, factory, depositAmount } =
+                await deployPortalFixture()
+
+            await factory.connect(owner).setOperator(operator.address, true)
+            await portal.connect(operator).setIsDepositEnabled(false)
+
+            await underlying.connect(user).approve(await portal.getAddress(), depositAmount)
+            await expect(
+                portal.connect(user).deposit(user.address, depositAmount, 0, 100, { value: 1000 })
+            ).to.be.revertedWithCustomError(portal, "DepositDisabled")
+
+            await portal.connect(operator).setIsDepositEnabled(true)
+            await expect(
+                portal.connect(user).deposit(user.address, depositAmount, 0, 100, { value: 1000 })
+            ).to.not.be.reverted
+        })
+    })
+
+    describe("factory configs", function () {
+        it("updates default deposit and withdraw fee configs as operator", async function () {
+            const { owner, operator, factory } = await deployFactoryFixture()
+            const operatorRole = await factory.OPERATOR_ROLE()
+            await factory.connect(owner).grantRole(operatorRole, operator.address)
+
+            await factory.connect(operator).setDefaultDepositFee(3, 100, 300)
+            await factory.connect(operator).setDefaultWithdrawFee(4, 200, 400)
+
+            const deposit = await factory.getFeeConfig(true)
+            expect(deposit.fixedFee).to.equal(3)
+            expect(deposit.percentageBps).to.equal(100)
+            expect(deposit.maxFee).to.equal(300)
+
+            const withdraw = await factory.getFeeConfig(false)
+            expect(withdraw.fixedFee).to.equal(4)
+            expect(withdraw.percentageBps).to.equal(200)
+            expect(withdraw.maxFee).to.equal(400)
+        })
+
+        it("updates fee and rescue recipients as admin only", async function () {
+            const { owner, operator, other, factory } = await deployFactoryFixture()
+
+            await factory.connect(owner).setFeeRecipient(other.address)
+            await factory.connect(owner).setRescueRecipient(operator.address)
+            expect(await factory.feeRecipient()).to.equal(other.address)
+            expect(await factory.rescueRecipient()).to.equal(operator.address)
+
+            await expect(
+                factory.connect(operator).setFeeRecipient(owner.address)
+            ).to.be.revertedWithCustomError(factory, "AccessControlUnauthorizedAccount")
+        })
+
+        it("updates price oracle as admin", async function () {
+            const { owner, operator, factory } = await deployFactoryFixture()
+
+            await expect(factory.connect(owner).setPriceOracle(operator.address))
+                .to.emit(factory, "PriceOracleUpdated")
+            expect(await factory.priceOracle()).to.equal(operator.address)
+        })
+
+        it("exposes isOperator for factory OPERATOR_ROLE", async function () {
+            const { owner, operator, factory } = await deployFactoryFixture()
+            expect(await factory.isOperator(owner.address)).to.equal(true)
+            expect(await factory.isOperator(operator.address)).to.equal(false)
+
+            const operatorRole = await factory.OPERATOR_ROLE()
+            await factory.connect(owner).grantRole(operatorRole, operator.address)
+            expect(await factory.isOperator(operator.address)).to.equal(true)
+        })
+    })
+
+    describe("factory roles propagate to all portals", function () {
+        async function deployTwoPortalsFixture() {
+            const [owner, user, operator, newAdmin] = await hre.ethers.getSigners()
+
+            const PortalImpl = await hre.ethers.getContractFactory("PrivacyPortal")
+            const portalImpl = await PortalImpl.deploy()
+            await portalImpl.waitForDeployment()
+
+            const PTokenImpl = await hre.ethers.getContractFactory("MockPodERC20ForPortal")
+            const pTokenImpl = await PTokenImpl.deploy()
+            await pTokenImpl.waitForDeployment()
+
+            const Factory = await hre.ethers.getContractFactory("PrivacyPortalFactory")
+            const factory = await Factory.deploy(
+                owner.address,
+                owner.address,
+                7082400,
+                newAdmin.address,
+                await pTokenImpl.getAddress(),
+                await portalImpl.getAddress(),
+                owner.address,
+                owner.address,
+                owner.address,
+                hre.ethers.ZeroAddress,
+                0,
+                0,
+                2n ** 128n - 1n,
+                0,
+                0,
+                2n ** 128n - 1n
+            )
+            await factory.waitForDeployment()
+
+            const MockERC20 = await hre.ethers.getContractFactory("MockERC20")
+            const underlyingA = await MockERC20.deploy("Token A", "AAA", 6)
+            await underlyingA.waitForDeployment()
+            const underlyingB = await MockERC20.deploy("Token B", "BBB", 6)
+            await underlyingB.waitForDeployment()
+
+            const pTokenA = await PTokenImpl.deploy()
+            await pTokenA.waitForDeployment()
+            const pTokenB = await PTokenImpl.deploy()
+            await pTokenB.waitForDeployment()
+
+            const CloneHelper = await hre.ethers.getContractFactory("CloneHelper")
+            const cloneHelper = await CloneHelper.deploy()
+            await cloneHelper.waitForDeployment()
+
+            await cloneHelper.clone(await portalImpl.getAddress())
+            const portalA = PortalImpl.attach(await cloneHelper.lastClone()) as Awaited<
+                ReturnType<typeof PortalImpl.deploy>
+            >
+            await portalA.initialize(
+                await underlyingA.getAddress(),
+                await pTokenA.getAddress(),
+                6,
+                false,
+                await factory.getAddress()
+            )
+
+            await cloneHelper.clone(await portalImpl.getAddress())
+            const portalB = PortalImpl.attach(await cloneHelper.lastClone()) as Awaited<
+                ReturnType<typeof PortalImpl.deploy>
+            >
+            await portalB.initialize(
+                await underlyingB.getAddress(),
+                await pTokenB.getAddress(),
+                6,
+                false,
+                await factory.getAddress()
+            )
+
+            return { owner, user, operator, newAdmin, factory, portalA, portalB }
+        }
+
+        it("respects factory admin on every portal and updates after admin transfer", async function () {
+            const { owner, user, newAdmin, factory, portalA, portalB } = await deployTwoPortalsFixture()
+            const adminRole = await factory.DEFAULT_ADMIN_ROLE()
+
+            expect(await factory.isAdmin(owner.address)).to.equal(true)
+            expect(await factory.isAdmin(newAdmin.address)).to.equal(false)
+
+            // Non-admin cannot pause either portal.
+            await expect(portalA.connect(user).pause()).to.be.revertedWithCustomError(
+                portalA,
+                "OnlyFactoryAdmin"
+            )
+            await expect(portalB.connect(user).pause()).to.be.revertedWithCustomError(
+                portalB,
+                "OnlyFactoryAdmin"
+            )
+
+            // Current factory admin can admin both portals.
+            await portalA.connect(owner).setLimits(1, 100, 1, 100)
+            await portalB.connect(owner).setLimits(2, 200, 2, 200)
+            expect(await portalA.minDepositAmount()).to.equal(1)
+            expect(await portalB.minDepositAmount()).to.equal(2)
+
+            // Grant + revoke DEFAULT_ADMIN_ROLE on the factory — both portals follow immediately.
+            await factory.connect(owner).grantRole(adminRole, newAdmin.address)
+            await factory.connect(owner).revokeRole(adminRole, owner.address)
+            expect(await factory.isAdmin(owner.address)).to.equal(false)
+            expect(await factory.isAdmin(newAdmin.address)).to.equal(true)
+
+            await expect(portalA.connect(owner).pause()).to.be.revertedWithCustomError(
+                portalA,
+                "OnlyFactoryAdmin"
+            )
+            await expect(portalB.connect(owner).setLimits(9, 99, 9, 99)).to.be.revertedWithCustomError(
+                portalB,
+                "OnlyFactoryAdmin"
+            )
+
+            await portalA.connect(newAdmin).pause()
+            await portalB.connect(newAdmin).pause()
+            expect(await portalA.paused()).to.equal(true)
+            expect(await portalB.paused()).to.equal(true)
+
+            await portalA.connect(newAdmin).unpause()
+            await portalB.connect(newAdmin).unpause()
+            await portalA.connect(newAdmin).addToBlacklist(user.address)
+            await portalB.connect(newAdmin).addToBlacklist(user.address)
+            expect(await portalA.blacklisted(user.address)).to.equal(true)
+            expect(await portalB.blacklisted(user.address)).to.equal(true)
+        })
+
+        it("respects factory operator on every portal and updates after operator revoke/grant", async function () {
+            const { owner, user, operator, factory, portalA, portalB } = await deployTwoPortalsFixture()
+            const operatorRole = await factory.OPERATOR_ROLE()
+
+            // Initial operator is constructor admin (owner); outsider cannot toggle soft deposits.
+            await expect(
+                portalA.connect(user).setIsDepositEnabled(false)
+            ).to.be.revertedWithCustomError(portalA, "OnlyFactoryOperator")
+            await expect(
+                portalB.connect(operator).setDepositFee(1, 0, 10)
+            ).to.be.revertedWithCustomError(portalB, "OnlyFactoryOperator")
+
+            await factory.connect(owner).grantRole(operatorRole, operator.address)
+            expect(await factory.isOperator(operator.address)).to.equal(true)
+
+            await portalA.connect(operator).setIsDepositEnabled(false)
+            await portalB.connect(operator).setIsDepositEnabled(false)
+            expect(await portalA.isDepositEnabled()).to.equal(false)
+            expect(await portalB.isDepositEnabled()).to.equal(false)
+
+            await portalA.connect(operator).setDepositFee(5, 0, 50)
+            await portalB.connect(operator).setWithdrawFee(7, 0, 70)
+            expect((await portalA.getFeeConfigOverride(true))[1]).to.equal(true)
+            expect((await portalB.getFeeConfigOverride(false))[1]).to.equal(true)
+
+            // Revoke OPERATOR_ROLE — both portals reject the former operator immediately.
+            await factory.connect(owner).revokeRole(operatorRole, operator.address)
+            expect(await factory.isOperator(operator.address)).to.equal(false)
+
+            await expect(
+                portalA.connect(operator).setIsDepositEnabled(true)
+            ).to.be.revertedWithCustomError(portalA, "OnlyFactoryOperator")
+            await expect(
+                portalB.connect(operator).clearDepositFeeOverride()
+            ).to.be.revertedWithCustomError(portalB, "OnlyFactoryOperator")
+
+            // Owner (still OPERATOR_ROLE from constructor) can clear overrides on both.
+            await portalA.connect(owner).clearDepositFeeOverride()
+            await portalB.connect(owner).clearWithdrawFeeOverride()
+            expect((await portalA.getFeeConfigOverride(true))[1]).to.equal(false)
+            expect((await portalB.getFeeConfigOverride(false))[1]).to.equal(false)
+        })
+    })
+
+    describe("portal factory-admin actions", function () {
+        it("lets factory admin manage portal blacklist independently of factory blacklist", async function () {
+            const { owner, user, portal, underlying, depositAmount } = await deployPortalFixture()
+
+            await portal.connect(owner).addToBlacklist(user.address)
+            await underlying.connect(user).approve(await portal.getAddress(), depositAmount)
+            await expect(
+                portal.connect(user).deposit(user.address, depositAmount, 0, 100, { value: 1000 })
+            ).to.be.revertedWithCustomError(portal, "AddressBlacklisted")
+
+            await portal.connect(owner).removeFromBlacklist(user.address)
+            await expect(
+                portal.connect(user).deposit(user.address, depositAmount, 0, 100, { value: 1000 })
+            ).to.not.be.reverted
         })
     })
 })

--- a/test/pod/privacy/PrivacyPortal.access.test.ts
+++ b/test/pod/privacy/PrivacyPortal.access.test.ts
@@ -36,9 +36,9 @@ describe("PrivacyPortal access controls", function () {
             await underlying.getAddress(),
             await pToken.getAddress(),
             6,
-            false
+            false,
+            await factory.getAddress()
         )
-        await portal.connect(owner).setPauseController(await factory.getAddress())
 
         const depositAmount = parseUnits("100", 6)
         await underlying.mint(user.address, depositAmount)
@@ -75,6 +75,7 @@ describe("PrivacyPortal access controls", function () {
             other.address,
             await pTokenImpl.getAddress(),
             await portalImpl.getAddress(),
+            owner.address,
             owner.address,
             owner.address,
             hre.ethers.ZeroAddress,
@@ -118,8 +119,7 @@ describe("PrivacyPortal access controls", function () {
         const portalAddress = await cloneHelper.lastClone()
         const portal = PortalImpl.attach(portalAddress) as Awaited<ReturnType<typeof PortalImpl.deploy>>
 
-        await portal.initialize(owner.address, wethAddress, await pToken.getAddress(), 18, true)
-        await portal.connect(owner).setPauseController(await factory.getAddress())
+        await portal.initialize(owner.address, wethAddress, await pToken.getAddress(), 18, true, await factory.getAddress())
 
         const depositAmount = parseEther("1")
 
@@ -329,6 +329,24 @@ describe("PrivacyPortal access controls", function () {
             const { owner, factory } = await deployFactoryFixture()
 
             expect(await factory.owner()).to.equal(owner.address)
+        })
+
+        it("lets admin set fee and rescue recipients", async function () {
+            const { owner, operator, other, factory } = await deployFactoryFixture()
+
+            await expect(factory.connect(owner).setFeeRecipient(other.address))
+                .to.emit(factory, "FeeRecipientUpdated")
+                .withArgs(owner.address, other.address)
+            expect(await factory.feeRecipient()).to.equal(other.address)
+
+            await expect(factory.connect(owner).setRescueRecipient(operator.address))
+                .to.emit(factory, "RescueRecipientUpdated")
+                .withArgs(owner.address, operator.address)
+            expect(await factory.rescueRecipient()).to.equal(operator.address)
+
+            await expect(
+                factory.connect(operator).setRescueRecipient(other.address)
+            ).to.be.revertedWithCustomError(factory, "AccessControlUnauthorizedAccount")
         })
 
         it("returns the first DEFAULT_ADMIN_ROLE holder when multiple admins exist", async function () {

--- a/test/pod/privacy/PrivacyPortal.recovery.test.ts
+++ b/test/pod/privacy/PrivacyPortal.recovery.test.ts
@@ -1,0 +1,267 @@
+import hre from "hardhat"
+import { expect } from "chai"
+import { parseUnits } from "ethers"
+
+describe("PrivacyPortal failed-request recovery", function () {
+    async function deployPortalFixture() {
+        const [owner, user, other] = await hre.ethers.getSigners()
+
+        const MockFactory = await hre.ethers.getContractFactory("MockPrivacyPortalFactory")
+        const factory = await MockFactory.deploy(owner.address, owner.address)
+        await factory.waitForDeployment()
+
+        const MockERC20 = await hre.ethers.getContractFactory("MockERC20")
+        const underlying = await MockERC20.deploy("Mock USD", "mUSD", 6)
+        await underlying.waitForDeployment()
+
+        const MockPToken = await hre.ethers.getContractFactory("MockPodERC20ForPortal")
+        const pToken = await MockPToken.deploy()
+        await pToken.waitForDeployment()
+
+        const PortalImpl = await hre.ethers.getContractFactory("PrivacyPortal")
+        const portalImpl = await PortalImpl.deploy()
+        await portalImpl.waitForDeployment()
+
+        const CloneHelper = await hre.ethers.getContractFactory("CloneHelper")
+        const cloneHelper = await CloneHelper.deploy()
+        await cloneHelper.waitForDeployment()
+
+        await cloneHelper.clone(await portalImpl.getAddress())
+        const portalAddress = await cloneHelper.lastClone()
+        const portal = PortalImpl.attach(portalAddress) as Awaited<ReturnType<typeof PortalImpl.deploy>>
+
+        await portal.initialize(
+            owner.address,
+            await underlying.getAddress(),
+            await pToken.getAddress(),
+            6,
+            false,
+            await factory.getAddress()
+        )
+
+        const amount = parseUnits("100", 6)
+        await underlying.mint(user.address, amount * 2n)
+        await underlying.connect(user).approve(await portal.getAddress(), amount * 2n)
+
+        return { owner, user, other, factory, underlying, pToken, portal, amount }
+    }
+
+    it("refunds locked underlying after a system-failed mint", async function () {
+        const { user, other, underlying, pToken, portal, amount } = await deployPortalFixture()
+
+        const tx = await portal.connect(user).deposit(user.address, amount, 0, 100, {
+            value: 1000,
+        })
+        const receipt = await tx.wait()
+        const depositLog = receipt!.logs
+            .map((log) => {
+                try {
+                    return portal.interface.parseLog(log)
+                } catch {
+                    return null
+                }
+            })
+            .find((parsed) => parsed?.name === "DepositRequested")
+        const requestId = depositLog!.args.mintRequestId as string
+
+        const feesLog = receipt!.logs
+            .map((log) => {
+                try {
+                    return portal.interface.parseLog(log)
+                } catch {
+                    return null
+                }
+            })
+            .find((parsed) => parsed?.name === "OperationFeesPaid")
+        expect(feesLog).to.not.equal(undefined)
+        expect(feesLog!.args.payer).to.equal(user.address)
+        expect(feesLog!.args.correlationId).to.equal(requestId)
+        expect(feesLog!.args.isDeposit).to.equal(true)
+        expect(feesLog!.args.isNativeWrap).to.equal(false)
+        expect(feesLog!.args.portalFee).to.equal(0n)
+        expect(feesLog!.args.podFee).to.equal(1000n)
+        expect(feesLog!.args.podCallbackFee).to.equal(100n)
+        expect(feesLog!.args.amount).to.equal(amount)
+
+        expect(await underlying.balanceOf(await portal.getAddress())).to.equal(amount)
+        await expect(portal.connect(user).refundFailedDeposit(requestId)).to.be.revertedWithCustomError(
+            portal,
+            "DepositMintNotFailed"
+        )
+
+        await pToken.markLastMintRaised()
+        await expect(portal.connect(user).refundFailedDeposit(requestId)).to.be.revertedWithCustomError(
+            portal,
+            "DepositMintNotFailed"
+        )
+
+        await pToken.markLastMintFailed()
+        const before = await underlying.balanceOf(user.address)
+        await expect(portal.connect(other).refundFailedDeposit(requestId)).to.be.revertedWithCustomError(
+            portal,
+            "OnlyDepositUser"
+        )
+        await expect(portal.connect(user).refundFailedDeposit(requestId))
+            .to.emit(portal, "DepositRefunded")
+            .withArgs(user.address, requestId, amount)
+
+        expect(await underlying.balanceOf(user.address)).to.equal(before + amount)
+        expect(await underlying.balanceOf(await portal.getAddress())).to.equal(0n)
+        await expect(portal.connect(user).refundFailedDeposit(requestId)).to.be.revertedWithCustomError(
+            portal,
+            "DepositEscrowInvalid"
+        )
+    })
+
+    it("marks withdrawal Failed when the pToken transfer request fails", async function () {
+        const { user, portal, pToken, amount } = await deployPortalFixture()
+
+        const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600)
+        const tx = await portal.connect(user).requestWithdrawWithPermit(
+            user.address,
+            amount,
+            0,
+            1000,
+            100,
+            deadline,
+            27,
+            hre.ethers.ZeroHash,
+            hre.ethers.ZeroHash,
+            { value: 1000 }
+        )
+        const receipt = await tx.wait()
+        const withdrawLog = receipt!.logs
+            .map((log) => {
+                try {
+                    return portal.interface.parseLog(log)
+                } catch {
+                    return null
+                }
+            })
+            .find((parsed) => parsed?.name === "WithdrawalRequested")
+        const withdrawalId = withdrawLog!.args.withdrawalId as string
+        const transferRequestId = withdrawLog!.args.transferRequestId as string
+
+        await expect(portal.cancelFailedWithdrawal(withdrawalId)).to.be.revertedWithCustomError(
+            portal,
+            "WithdrawTransferNotFailed"
+        )
+
+        await pToken.markLastTransferFailed()
+        await expect(portal.cancelFailedWithdrawal(withdrawalId))
+            .to.emit(portal, "WithdrawalFailed")
+            .withArgs(withdrawalId, transferRequestId)
+
+        const feesLog = receipt!.logs
+            .map((log) => {
+                try {
+                    return portal.interface.parseLog(log)
+                } catch {
+                    return null
+                }
+            })
+            .find((parsed) => parsed?.name === "OperationFeesPaid")
+        expect(feesLog).to.not.equal(undefined)
+        expect(feesLog!.args.correlationId).to.equal(withdrawalId)
+        expect(feesLog!.args.isDeposit).to.equal(false)
+        expect(feesLog!.args.portalFee).to.equal(0n)
+        expect(feesLog!.args.podFee).to.equal(1000n)
+        expect(feesLog!.args.podCallbackFee).to.equal(100n)
+
+        const withdrawal = await portal.withdrawals(withdrawalId)
+        expect(withdrawal.status).to.equal(3n) // WithdrawalStatus.Failed
+        await expect(portal.cancelFailedWithdrawal(withdrawalId)).to.be.revertedWithCustomError(
+            portal,
+            "WithdrawalNotPending"
+        )
+        await expect(portal.triggerWithdrawalRelease(withdrawalId)).to.be.revertedWithCustomError(
+            portal,
+            "WithdrawalNotPending"
+        )
+    })
+
+    it("cancels withdrawal after a system-failed pToken transfer", async function () {
+        const { user, portal, pToken, amount } = await deployPortalFixture()
+
+        const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600)
+        const tx = await portal.connect(user).requestWithdrawWithPermit(
+            user.address,
+            amount,
+            0,
+            1000,
+            100,
+            deadline,
+            27,
+            hre.ethers.ZeroHash,
+            hre.ethers.ZeroHash,
+            { value: 1000 }
+        )
+        const receipt = await tx.wait()
+        const withdrawLog = receipt!.logs
+            .map((log) => {
+                try {
+                    return portal.interface.parseLog(log)
+                } catch {
+                    return null
+                }
+            })
+            .find((parsed) => parsed?.name === "WithdrawalRequested")
+        const withdrawalId = withdrawLog!.args.withdrawalId as string
+        const transferRequestId = withdrawLog!.args.transferRequestId as string
+
+        await pToken.markLastTransferSystemFailed()
+        await expect(portal.cancelFailedWithdrawal(withdrawalId))
+            .to.emit(portal, "WithdrawalFailed")
+            .withArgs(withdrawalId, transferRequestId)
+
+        const withdrawal = await portal.withdrawals(withdrawalId)
+        expect(withdrawal.status).to.equal(3n) // WithdrawalStatus.Failed
+    })
+
+    it("rescues native and ERC20 to the factory rescue recipient while paused", async function () {
+        const { owner, other, factory, underlying, portal, pToken } = await deployPortalFixture()
+        const rescueTo = other.address
+        await factory.setRescueRecipient(rescueTo)
+
+        await owner.sendTransaction({ to: await portal.getAddress(), value: parseUnits("1", 18) })
+        await underlying.mint(await portal.getAddress(), parseUnits("50", 6))
+
+        await expect(portal.connect(owner).rescueNative(parseUnits("1", 18))).to.be.revertedWithCustomError(
+            portal,
+            "ExpectedPause"
+        )
+
+        await portal.connect(owner).pause()
+        const rescueNativeAmount = parseUnits("0.4", 18)
+        await expect(portal.connect(owner).rescueNative(rescueNativeAmount))
+            .to.emit(portal, "NativeRescued")
+            .withArgs(rescueTo, rescueNativeAmount)
+
+        const rescueErc20Amount = parseUnits("25", 6)
+        await expect(portal.connect(owner).rescueERC20(await underlying.getAddress(), rescueErc20Amount))
+            .to.emit(portal, "ERC20Rescued")
+            .withArgs(await underlying.getAddress(), rescueTo, rescueErc20Amount)
+
+        await expect(
+            portal.connect(owner).rescueERC20(await pToken.getAddress(), 1)
+        ).to.be.revertedWithCustomError(portal, "CannotRescuePToken")
+    })
+
+    it("sweeps portal fees to the factory fee recipient", async function () {
+        const { owner, user, factory, portal, underlying, amount } = await deployPortalFixture()
+        expect(await factory.feeRecipient()).to.equal(owner.address)
+
+        await portal.connect(owner).setDepositFee(100, 0, parseUnits("1", 18))
+        await underlying.connect(user).approve(await portal.getAddress(), amount)
+        await portal.connect(user).deposit(user.address, amount, 100, 100, { value: 1100 })
+
+        expect(await portal.accumulatedPortalFees()).to.equal(100n)
+        const before = await hre.ethers.provider.getBalance(owner.address)
+        const tx = await portal.connect(owner).withdrawPortalFees(100)
+        const receipt = await tx.wait()
+        const gas = receipt!.gasUsed * receipt!.gasPrice
+        const after = await hre.ethers.provider.getBalance(owner.address)
+        expect(after + gas - before).to.equal(100n)
+        expect(await portal.accumulatedPortalFees()).to.equal(0n)
+    })
+})

--- a/test/pod/privacy/PrivacyPortal.recovery.test.ts
+++ b/test/pod/privacy/PrivacyPortal.recovery.test.ts
@@ -31,7 +31,6 @@ describe("PrivacyPortal failed-request recovery", function () {
         const portal = PortalImpl.attach(portalAddress) as Awaited<ReturnType<typeof PortalImpl.deploy>>
 
         await portal.initialize(
-            owner.address,
             await underlying.getAddress(),
             await pToken.getAddress(),
             6,

--- a/test/pod/privacy/PrivacyPortal.recovery.test.ts
+++ b/test/pod/privacy/PrivacyPortal.recovery.test.ts
@@ -96,11 +96,8 @@ describe("PrivacyPortal failed-request recovery", function () {
 
         await pToken.markLastMintFailed()
         const before = await underlying.balanceOf(user.address)
-        await expect(portal.connect(other).refundFailedDeposit(requestId)).to.be.revertedWithCustomError(
-            portal,
-            "OnlyDepositUser"
-        )
-        await expect(portal.connect(user).refundFailedDeposit(requestId))
+        // Permissionless: a third party may trigger; funds still return to the depositor.
+        await expect(portal.connect(other).refundFailedDeposit(requestId))
             .to.emit(portal, "DepositRefunded")
             .withArgs(user.address, requestId, amount)
 


### PR DESCRIPTION
- Factory owns `feeRecipient` + `rescueRecipient` (admin setters); portals read rescue from factory.
- Explicit `factory` on portal initialize; drop per-portal rescue arg from `createPortal` / `initialize`.
- Expand access + recovery/failure-path tests (refund vs SystemFailed, cancel, rescue, fee sweep).
- Update mocks (`MockPrivacyPortalFactory`, `MockPodERC20ForPortal`).
**Include:** `contracts/pod/privacy/**`, related perc20/inbox touchpoints if intentional, `test/pod/privacy/**`.
**Skip:** regenerated typechain noise unless the repo always commits it.
- Add `hardhat.mpc.config.ts` / `hardhat.sim.config.ts`, `scripts/link-sim-coti.sh`, `simCotiHardhat2` + smoke tests.
- Wire `package.json` scripts (`link` / `compile` / `test:sim-coti`); depend on `@coti-io/sim-coti-node`.
- Raise Precompile gas + Hardhat `blockGasLimit` for TransferWithAllowance casting suites (documented in config).
- Slim-stage Precompile mocks via link script to keep compile manageable.
**Include:** configs, scripts, `test/utils/simCoti*.ts`, `test/utils/accounts.ts`, `test/utils/mpc/Precompile.test.ts`, `package.json` / lockfile.
