### PR TITLE
Make coti-contracts SoT for shared PoD APIs

### DIFF
--- a/contracts/oracle/IStdReference.sol
+++ b/contracts/oracle/IStdReference.sol
@@ -1,26 +1,27 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-/**
- * @title IStdReference
- * @notice Band Protocol Standard Reference interface for querying price data.
- */
+/// @title IStdReference
+/// @notice Minimal Band Protocol StdReference interface (no npm dependency).
+/// @dev Canonical SoT for Band lookups used by PoD inbox fee adapters and COTI oracle helpers.
+///      Implementations are trusted for rate correctness; callers validate staleness and non-zero rates.
 interface IStdReference {
+    /// @notice Band reference quote: `rate` is base/quote scaled by 1e18.
     struct ReferenceData {
-        uint256 rate;            // base/quote exchange rate, scaled by 1e18
-        uint256 lastUpdatedBase; // UNIX epoch when the base price was last updated
-        uint256 lastUpdatedQuote; // UNIX epoch when the quote price was last updated
+        uint256 rate;
+        uint256 lastUpdatedBase;
+        uint256 lastUpdatedQuote;
     }
 
-    /// @notice Returns the price data for a single base/quote pair.
-    function getReferenceData(
-        string memory _base,
-        string memory _quote
-    ) external view returns (ReferenceData memory);
+    /// @notice Single base/quote pair lookup.
+    function getReferenceData(string memory base, string memory quote)
+        external
+        view
+        returns (ReferenceData memory);
 
-    /// @notice Returns the price data for multiple base/quote pairs.
-    function getReferenceDataBulk(
-        string[] memory _bases,
-        string[] memory _quotes
-    ) external view returns (ReferenceData[] memory);
+    /// @notice Parallel lookup for multiple pairs (same-length arrays).
+    function getReferenceDataBulk(string[] memory bases, string[] memory quotes)
+        external
+        view
+        returns (ReferenceData[] memory);
 }

--- a/contracts/pod/privacy/IPodPriceOracle.sol
+++ b/contracts/pod/privacy/IPodPriceOracle.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.20;
 
 /// @title IPodPriceOracle
 /// @notice Live USD price reads keyed by ERC-20 token address (18-decimal USD per whole token).
-/// @dev Must stay in sync with coti-pod-inbox-contracts/contracts/fee/IPodPriceOracle.sol
+/// @dev Canonical SoT for PoD live-price reads. Inbox fee adapters and Privacy Portal import this file.
 ///
 /// Implemented by {PoDPriceOracle} (portal + inbox), {BandLiveOracle}, and {ChainlinkLiveOracle}.
 /// Feed adapters never revert; return `0` when a feed is unset, stale, or failed.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "url": "https://github.com/coti-io/coti-contracts.git"
   },
   "homepage": "https://docs.coti.io/coti-v2-documentation/build-on-coti/tools/contracts-library",
+  "files": [
+    "contracts/**/*.sol",
+    "LICENSE",
+    "README.md"
+  ],
   "keywords": [
     "coti",
     "privacy",


### PR DESCRIPTION
## Summary
- Expose Solidity sources via `package.json` `files` so `@coti-io/coti-contracts` installs work for Hardhat/`file:` consumers.
- Normalize `IStdReference` / `IPodPriceOracle` natspec as the canonical shared oracle APIs.
- Enables inbox + PEI to import shared PoD interfaces from this package instead of local copies / `sync:interfaces`.

## Test plan
- [ ] Confirm `files` includes `contracts/**/*.sol`
- [ ] Sibling install: `cd ../coti-pod-inbox-contracts && npm install && npx hardhat compile`
- [ ] Optional: `npm run compile` on a runner with native solc (WASM may OOM on aarch64)

Companion PRs: inbox + PEI dedupe branches.

Made with [Cursor](https://cursor.com)