### PR TITLE
fix(access): gate DataPrivacyFramework permission mutators to admin

### DIFF
--- a/contracts/access/DataPrivacyFramework/DataPrivacyFramework.sol
+++ b/contracts/access/DataPrivacyFramework/DataPrivacyFramework.sol
@@ -74,6 +74,12 @@ abstract contract DataPrivacyFramework {
         _;
     }
 
+    /// @dev Permission mutators must be gated; the constructor seeds the deployer with "admin".
+    modifier onlyAdmin() {
+        require(this.isOperationAllowed(msg.sender, "admin"), "DPF: ADMIN_ONLY");
+        _;
+    }
+
     /**
      * @param addressDefaultPermission_ default address permission
      * @param operationDefaultPermission_  default operation permission
@@ -85,12 +91,13 @@ abstract contract DataPrivacyFramework {
         // set admin permissions
         allowedOperations["admin"] = true;
 
-        setPermission(InputData(msg.sender, "admin", true, 0, 0, false, false, 0, address(0), ""));
+        // Bootstrap via internal setter (public mutators are onlyAdmin).
+        _setPermission(InputData(msg.sender, "admin", true, 0, 0, false, false, 0, address(0), ""));
 
         // by default we allow all users and all operations
         allowedOperations[STRING_ALL] = true;
 
-        setPermission(InputData(ADDRESS_ALL, STRING_ALL, true, 0, 0, false, false, 0, address(0), ""));
+        _setPermission(InputData(ADDRESS_ALL, STRING_ALL, true, 0, 0, false, false, 0, address(0), ""));
     }
 
     /**
@@ -241,7 +248,7 @@ abstract contract DataPrivacyFramework {
      * @param defaultPermission new value of the default address permission
      * @return _ boolean indicating if the update succeeded
      */
-    function setAddressDefaultPermission(bool defaultPermission) external returns (bool) {
+    function setAddressDefaultPermission(bool defaultPermission) external virtual onlyAdmin returns (bool) {
         require(addressDefaultPermission != defaultPermission, "DPF: INVALID_PERMISSION_CHANGE");
 
         addressDefaultPermission = defaultPermission;
@@ -254,7 +261,7 @@ abstract contract DataPrivacyFramework {
      * @param defaultPermission new value of the default operation permission
      * @return _ boolean indicating if the update succeeded
      */
-    function setOperationDefaultPermission(bool defaultPermission) external returns (bool) {
+    function setOperationDefaultPermission(bool defaultPermission) external virtual onlyAdmin returns (bool) {
         require(operationDefaultPermission != defaultPermission, "DPF: INVALID_PERMISSION_CHANGE");
 
         operationDefaultPermission = defaultPermission;
@@ -267,7 +274,7 @@ abstract contract DataPrivacyFramework {
      * @param operation the operation to allow
      * @return _ boolean indicating if the update succeeded
      */
-    function addAllowedOperation(string memory operation) public returns (bool) {
+    function addAllowedOperation(string memory operation) public virtual onlyAdmin returns (bool) {
         require(!allowedOperations[operation], "DPF: OPERATION_ALREADY_ALLOWED");
 
         allowedOperations[operation] = true;
@@ -280,7 +287,7 @@ abstract contract DataPrivacyFramework {
      * @param operation the operation to remove
      * @return _ boolean indicating if the update succeeded
      */
-    function removeAllowedOperation(string calldata operation) external returns (bool) {
+    function removeAllowedOperation(string calldata operation) external virtual onlyAdmin returns (bool) {
         require(allowedOperations[operation], "DPF: OPERATION_NOT_ALLOWED");
 
         allowedOperations[operation] = false;
@@ -293,7 +300,7 @@ abstract contract DataPrivacyFramework {
      * @param operation the operation to restrict
      * @return _ boolean indicating if the update succeeded
      */
-    function addRestrictedOperation(string memory operation) public returns (bool) {
+    function addRestrictedOperation(string memory operation) public virtual onlyAdmin returns (bool) {
         require(!restrictedOperations[operation], "DPF: OPERATION_ALREADY_RESTRICTED");
 
         restrictedOperations[operation] = true;
@@ -306,7 +313,7 @@ abstract contract DataPrivacyFramework {
      * @param operation the operation to remove
      * @return _ boolean indicating if the update succeeded
      */
-    function removeRestrictedOperation(string calldata operation) external returns (bool) {
+    function removeRestrictedOperation(string calldata operation) external virtual onlyAdmin returns (bool) {
         require(restrictedOperations[operation], "DPF: OPERATION_NOT_RESTRICTED");
 
         restrictedOperations[operation] = false;
@@ -319,7 +326,11 @@ abstract contract DataPrivacyFramework {
      * @param inputData struct containing the parameters of the new permission
      * @return _ boolean indicating if the update succeeded
      */
-    function setPermission(InputData memory inputData) public returns (bool) {
+    function setPermission(InputData memory inputData) public virtual onlyAdmin returns (bool) {
+        return _setPermission(inputData);
+    }
+
+    function _setPermission(InputData memory inputData) internal returns (bool) {
         if (permissions[inputData.caller][inputData.operation] == 0) {
             permissions[inputData.caller][inputData.operation] = _conditionsCount;
 

--- a/test/access/DataPrivacyFramework/DataPrivacyFramework.test.ts
+++ b/test/access/DataPrivacyFramework/DataPrivacyFramework.test.ts
@@ -777,4 +777,43 @@ describe("Data Privacy Framework", function () {
       expect(permissionGranted).to.equal(true)
     })
   })
+
+  describe("Admin gate on permission mutators", function () {
+    it("Non-admin cannot call setPermission", async function () {
+      const { contract, otherAccount } = deployment
+
+      const inputData = {
+        caller: await otherAccount.getAddress(),
+        operation: "op_decrypt",
+        active: true,
+        timestampBefore: "0",
+        timestampAfter: "0",
+        falseKey: false,
+        trueKey: true,
+        uintParameter: "0",
+        addressParameter: "0x0000000000000000000000000000000000000000",
+        stringParameter: "",
+      }
+
+      await expect(contract.connect(otherAccount).setPermission(inputData)).to.be.revertedWith(
+        "DPF: ADMIN_ONLY",
+      )
+    })
+
+    it("Non-admin cannot call addAllowedOperation", async function () {
+      const { contract, otherAccount } = deployment
+
+      await expect(contract.connect(otherAccount).addAllowedOperation("op_decrypt")).to.be.revertedWith(
+        "DPF: ADMIN_ONLY",
+      )
+    })
+
+    it("Non-admin cannot call setAddressDefaultPermission", async function () {
+      const { contract, otherAccount } = deployment
+
+      await expect(contract.connect(otherAccount).setAddressDefaultPermission(false)).to.be.revertedWith(
+        "DPF: ADMIN_ONLY",
+      )
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Closes https://github.com/coti-io/coti-contracts/issues/75.

`DataPrivacyFramework` permission mutators were callable by any address while `DataPrivacyFrameworkMpc` gates MPC ops (including `op_decrypt`) on that same store. The constructor already seeds the deployer with `"admin"` but never required it for mutators.

## Fix

- `onlyAdmin` on all seven mutators (`isOperationAllowed(msg.sender, "admin")`)
- Constructor bootstraps via internal `_setPermission`
- Mutators marked `virtual` for integrator overrides

**Note:** potentially breaking for anyone who relied on open mutators in a published package.

## Test plan

- [x] Non-admin `setPermission` / `addAllowedOperation` / `setAddressDefaultPermission` revert with `DPF: ADMIN_ONLY`
- [ ] Existing suite still passes for deployer/admin paths


Made with [Cursor](https://cursor.com)