### PR TITLE
Restructure PodERC20 into OZ-style burnable/pausable extensions

### DIFF
--- a/contracts/pod/token/perc20/IPodERC20.sol
+++ b/contracts/pod/token/perc20/IPodERC20.sol
@@ -61,9 +61,47 @@ interface IPodERC20 {
         bytes32 s;
     }
 
-    // --- Functions ---
-    // Events ({Transfer}, {Approval}, etc.) are declared on {PodERC20} / {PodERC20Burnable}, not here,
-    // so the bare base can emit without implementing {burn}.
+    // --- Events ---
+
+    /**
+     * @notice Tokens moved from `from` to `to` after the COTI leg succeeded and this contract applied ciphertext updates.
+     * @dev `senderValue` / `receiverValue` are the same logical amount re-encrypted for each party; either may be zero in edge cases.
+     */
+    event Transfer(
+        address indexed from,
+        address indexed to,
+        ctUint256 senderValue,
+        ctUint256 receiverValue
+    );
+
+    /// @notice The asynchronous transfer failed on the COTI side or was rejected before balances were updated.
+    event TransferFailed(address indexed from, address indexed to, bytes errorMsg);
+
+    /**
+     * @notice Allowance for `spender` on `owner` was updated after a successful COTI `approve`.
+     * @dev `ownerValue` and `spenderValue` encrypt the same allowance amount for different AES keys.
+     */
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        ctUint256 ownerValue,
+        ctUint256 spenderValue
+    );
+
+    /// @notice `transferAndCall` delivered tokens but the post-transfer `to.call(callbackData)` reverted or ran out of gas.
+    event RequestCallbackFailed(address from, address to, bytes32 requestId, bytes callbackData);
+
+    /// @notice `syncBalances` refreshed `account` from the COTI ledger when the monotonic `nonce` allowed it.
+    event BalanceSynced(address account, ctUint256 amount);
+
+    /// @notice Balance ciphertext was not applied because the account nonce was already current or newer.
+    event BalanceSyncSkipped(address indexed account, uint256 incomingNonce, uint256 currentNonce);
+
+    /// @notice Lifecycle transition for an async inbox request submitted by this token.
+    event RequestStatusUpdated(bytes32 indexed requestId, RequestStatus status);
+
+    /// @notice Owner killed a stale Pending request after the configured minimum age.
+    event StaleRequestKilled(bytes32 indexed requestId, address indexed account, address indexed spender);
 
     // --- Token metadata & supply ---
 

--- a/contracts/pod/token/perc20/IPodERC20.sol
+++ b/contracts/pod/token/perc20/IPodERC20.sol
@@ -61,47 +61,9 @@ interface IPodERC20 {
         bytes32 s;
     }
 
-    // --- Events ---
-
-    /**
-     * @notice Tokens moved from `from` to `to` after the COTI leg succeeded and this contract applied ciphertext updates.
-     * @dev `senderValue` / `receiverValue` are the same logical amount re-encrypted for each party; either may be zero in edge cases.
-     */
-    event Transfer(
-        address indexed from,
-        address indexed to,
-        ctUint256 senderValue,
-        ctUint256 receiverValue
-    );
-
-    /// @notice The asynchronous transfer failed on the COTI side or was rejected before balances were updated.
-    event TransferFailed(address indexed from, address indexed to, bytes errorMsg);
-
-    /**
-     * @notice Allowance for `spender` on `owner` was updated after a successful COTI `approve`.
-     * @dev `ownerValue` and `spenderValue` encrypt the same allowance amount for different AES keys.
-     */
-    event Approval(
-        address indexed owner,
-        address indexed spender,
-        ctUint256 ownerValue,
-        ctUint256 spenderValue
-    );
-
-    /// @notice `transferAndCall` delivered tokens but the post-transfer `to.call(callbackData)` reverted or ran out of gas.
-    event RequestCallbackFailed(address from, address to, bytes32 requestId, bytes callbackData);
-
-    /// @notice `syncBalances` refreshed `account` from the COTI ledger when the monotonic `nonce` allowed it.
-    event BalanceSynced(address account, ctUint256 amount);
-
-    /// @notice Balance ciphertext was not applied because the account nonce was already current or newer.
-    event BalanceSyncSkipped(address indexed account, uint256 incomingNonce, uint256 currentNonce);
-
-    /// @notice Lifecycle transition for an async inbox request submitted by this token.
-    event RequestStatusUpdated(bytes32 indexed requestId, RequestStatus status);
-
-    /// @notice Owner killed a stale Pending request after the configured minimum age.
-    event StaleRequestKilled(bytes32 indexed requestId, address indexed account, address indexed spender);
+    // --- Functions ---
+    // Events ({Transfer}, {Approval}, etc.) are declared on {PodERC20} / {PodERC20Burnable}, not here,
+    // so the bare base can emit without implementing {burn}.
 
     // --- Token metadata & supply ---
 

--- a/contracts/pod/token/perc20/PodERC20.sol
+++ b/contracts/pod/token/perc20/PodERC20.sol
@@ -12,12 +12,13 @@ import "./cotiside/IPodErc20CotiSide.sol";
 import "../erc7984/PodErc7984Mixin.sol";
 
 /// @title PodERC20
-/// @notice PoD-side private ERC-20: ciphertext cache and inbox-mediated async moves; COTI holds authoritative garbled state via {IPodErc20CotiSide}.
-/// @dev Callbacks only from `inbox` when the remote peer matches (`cotiChainId`, `cotiSideContract`). Public-amount methods expose amounts in calldata and logs; use encrypted `itUint256` entry points for privacy-sensitive flows.
+/// @notice Bare PoD-side private ERC-20: ciphertext cache and inbox-mediated async moves; COTI holds authoritative garbled state via {IPodErc20CotiSide}.
+/// @dev Base token without public {burn}; use {PodERC20Burnable} for burn entry points (see {PodErc20Mintable} for Privacy Portal pTokens).
+///      Callbacks only from `inbox` when the remote peer matches (`cotiChainId`, `cotiSideContract`). Public-amount methods expose amounts in calldata and logs; use encrypted `itUint256` entry points for privacy-sensitive flows.
 ///      {_sendPodTwoWay} is `nonReentrant` so a compromised inbox/oracle cannot re-enter before pending state is written.
 ///      Uses storage `ReentrancyGuard` (not transient) so the whole tree can compile for Paris — COTI rejects Shanghai `PUSH0`.
 ///      Owner may rotate inbox / COTI peer via {configure}.
-contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Ownable {
+contract PodERC20 is InboxUser, PodErc7984Mixin, ReentrancyGuard, Ownable {
     using MpcAbiCodec for MpcAbiCodec.MpcMethodCallContext;
 
     /// @notice Maximum accounts per {syncBalances} batch (reply-size / gas bound).
@@ -66,7 +67,28 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
     /// @notice Minimum age (seconds) before {killStaleRequest} may terminalize a Pending request (`0` = no wait).
     uint64 public requestKillMinAge = 1 days;
 
-    // --- Events (PoD-specific; {Transfer}, {Approval}, etc. are declared on {IPodERC20}) ---
+    // --- Events ({IPodERC20} events redeclared here so {PodERC20} can emit without implementing burn) ---
+
+    event Transfer(
+        address indexed from,
+        address indexed to,
+        ctUint256 senderValue,
+        ctUint256 receiverValue
+    );
+    event TransferFailed(address indexed from, address indexed to, bytes errorMsg);
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        ctUint256 ownerValue,
+        ctUint256 spenderValue
+    );
+    event RequestCallbackFailed(address from, address to, bytes32 requestId, bytes callbackData);
+    event BalanceSynced(address account, ctUint256 amount);
+    event BalanceSyncSkipped(address indexed account, uint256 incomingNonce, uint256 currentNonce);
+    event RequestStatusUpdated(bytes32 indexed requestId, IPodERC20.RequestStatus status);
+    event StaleRequestKilled(bytes32 indexed requestId, address indexed account, address indexed spender);
+
+    // --- Events (PoD-specific) ---
 
     /// @notice Async transfer request was submitted to COTI.
     event TransferRequestSubmitted(address indexed from, address indexed to, bytes32 requestId);
@@ -168,32 +190,32 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
     // --- External: mutating (user / admin) ---
 
     /**
-     * @inheritdoc IPodERC20
+     * @dev See {IPodERC20}.
      * @dev **Gotcha:** `TransferRequestSubmitted` indexes `msg.sender` as `from`, not the `from` argument of internal `_transfer` (same for direct `transfer`).
      */
     function transfer(address to, itUint256 calldata value, uint256 callbackFeeLocalWei) external payable returns (bytes32 requestId) {
         return _transfer(IPodErc20CotiSide.transfer.selector, msg.sender, to, value, msg.value, callbackFeeLocalWei);
     }
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function transfer(address to, itUint256 calldata value) external payable returns (bytes32 requestId) {
         (, uint256 callbackFeeLocalWei) = _estimateTwoWayFeeInLocalToken();
         return _transfer(IPodErc20CotiSide.transfer.selector, msg.sender, to, value, msg.value, callbackFeeLocalWei);
     }
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function transferFrom(address from, address to, itUint256 calldata value, uint256 callbackFeeLocalWei) external payable returns (bytes32 requestId) {
         return _transferFrom(IPodErc20CotiSide.transferFromAsSpender.selector, msg.sender, from, to, value, msg.value, callbackFeeLocalWei);
     }
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function transferFrom(address from, address to, itUint256 calldata value) external payable returns (bytes32 requestId) {
         (, uint256 callbackFeeLocalWei) = _estimateTwoWayFeeInLocalToken();
         return _transferFrom(IPodErc20CotiSide.transferFromAsSpender.selector, msg.sender, from, to, value, msg.value, callbackFeeLocalWei);
     }
 
     /**
-     * @inheritdoc IPodERC20
+     * @dev See {IPodERC20}.
      * @dev Stores `data` under the new `requestId` until {transferCallback} runs successfully and forwards it to `to`.
      *      Concurrent transfers may complete out of order; receivers must key hooks on `requestId`, not arrival order.
      */
@@ -208,7 +230,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
         return requestId;
     }
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function transferFromAndCall(
         address from,
         address to,
@@ -228,12 +250,12 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
         _requestCallbacks[requestId] = data;
     }
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function transferFromAndCallWithPermit(
         address from,
         address to,
         uint256 amount,
-        PublicPermit calldata permit,
+        IPodERC20.PublicPermit calldata permit,
         bytes calldata data,
         uint256 callbackFeeLocalWei
     ) external payable returns (bytes32 requestId) {
@@ -249,23 +271,18 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
         _requestCallbacks[requestId] = data;
     }
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function approve(address spender, itUint256 calldata value, uint256 callbackFeeLocalWei) external payable returns (bytes32 requestId) {
         return _approve(msg.sender, spender, value, msg.value, callbackFeeLocalWei);
     }
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function approve(address spender, itUint256 calldata value) external payable returns (bytes32 requestId) {
         (, uint256 callbackFeeLocalWei) = _estimateTwoWayFeeInLocalToken();
         return _approve(msg.sender, spender, value, msg.value, callbackFeeLocalWei);
     }
 
-    /// @inheritdoc IPodERC20
-    function burn(itUint256 calldata value, uint256 callbackFeeLocalWei) external payable returns (bytes32 requestId) {
-        return _burn(msg.sender, value, msg.value, callbackFeeLocalWei);
-    }
-
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function mint(address to, itUint256 calldata amount, uint256 callbackFeeLocalWei) external payable returns (bytes32 requestId) {
         _checkMinter();
         return _mint(to, amount, msg.value, callbackFeeLocalWei);
@@ -273,34 +290,29 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
 
     // --- External: mutating (plain uint256 variants) ---
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function transfer(address to, uint256 amount, uint256 callbackFeeLocalWei) external payable returns (bytes32 requestId) {
         return _transferPublic(IPodErc20CotiSide.transferPublic.selector, msg.sender, to, amount, msg.value, callbackFeeLocalWei);
     }
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function transferFrom(address from, address to, uint256 amount, uint256 callbackFeeLocalWei) external payable returns (bytes32 requestId) {
         return _transferPublicFrom(IPodErc20CotiSide.transferFromPublicAsSpender.selector, msg.sender, from, to, amount, msg.value, callbackFeeLocalWei);
     }
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function approve(address spender, uint256 amount, uint256 callbackFeeLocalWei) external payable returns (bytes32 requestId) {
         return _approvePublic(msg.sender, spender, amount, msg.value, callbackFeeLocalWei);
     }
 
-    /// @inheritdoc IPodERC20
-    function burn(uint256 amount, uint256 callbackFeeLocalWei) external payable returns (bytes32 requestId) {
-        return _burnPublic(msg.sender, amount, msg.value, callbackFeeLocalWei);
-    }
-
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function mint(address to, uint256 amount, uint256 callbackFeeLocalWei) external payable returns (bytes32 requestId) {
         _checkMinter();
         return _mintPublic(to, amount, msg.value, callbackFeeLocalWei);
     }
 
     /**
-     * @inheritdoc IPodERC20
+     * @dev See {IPodERC20}.
      * @dev Does not change {pendingTransferCount}; only transfers/burns/mints adjust that counter.
      */
     function syncBalances(address[] calldata accounts, uint256 callbackFeeLocalWei) external payable returns (bytes32 requestId) {
@@ -385,7 +397,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
             (address, ctUint256, address, ctUint256)
         );
         _clearPendingByRequestId(sourceRequestId);
-        _allowance[owner][spender] = Allowance({spenderCiphertext: spenderAmount, ownerCiphertext: ownerAmount});
+        _allowance[owner][spender] = IPodERC20.Allowance({spenderCiphertext: spenderAmount, ownerCiphertext: ownerAmount});
         emit Approval(owner, spender, ownerAmount, spenderAmount);
     }
 
@@ -468,31 +480,31 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
 
     // --- External: views ---
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function requests(bytes32 requestId) external view returns (IPodERC20.RequestRecord memory) {
         return _requests[requestId];
     }
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function balanceOf(address account) external view returns (ctUint256 memory) {
         return _balances[account];
     }
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function balanceOfWithStatus(address account) external view returns (ctUint256 memory, bool pending) {
         return (_balances[account], pendingTransferCount[account] > 0);
     }
 
-    /// @inheritdoc IPodERC20
-    function allowance(address owner, address spender) external view returns (Allowance memory) {
+    /// @dev See {IPodERC20}.
+    function allowance(address owner, address spender) external view returns (IPodERC20.Allowance memory) {
         return _allowance[owner][spender];
     }
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     function allowanceWithStatus(
         address owner,
         address spender
-    ) external view returns (Allowance memory, bool pending) {
+    ) external view returns (IPodERC20.Allowance memory, bool pending) {
         return (_allowance[owner][spender], _pendingApprovalRequestIds[owner][spender] != bytes32(0));
     }
 
@@ -579,13 +591,13 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
         _clearPendingByRequestId(requestId);
     }
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     /// @dev Factory-deployed tokens: call via {IPrivacyPortalFactoryAdmin.setPTokenRequestKillMinAge}.
     function setRequestKillMinAge(uint64 seconds_) external onlyOwner {
         requestKillMinAge = seconds_;
     }
 
-    /// @inheritdoc IPodERC20
+    /// @dev See {IPodERC20}.
     /// @dev Factory-deployed tokens: call via {IPrivacyPortalFactoryAdmin.killPTokenStaleRequest}.
     function killStaleRequest(bytes32 requestId) external onlyOwner {
         IPodERC20.RequestRecord storage rec = _requests[requestId];
@@ -611,7 +623,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
         IInbox.MpcMethodCall memory mpcMethodCall,
         bytes4 callbackSelector_,
         bytes4 errorSelector_
-    ) internal nonReentrant returns (bytes32) {
+    ) internal virtual nonReentrant returns (bytes32) {
         require(callbackFeeLocalWei >= 1, "PodERC20: callback fee min");
         require(callbackFeeLocalWei <= totalValueWei, "PodERC20: callback exceeds total");
         require(address(this).balance >= totalValueWei, "PodERC20: inbox fee");
@@ -855,7 +867,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
         address spender,
         address to,
         uint256 amount,
-        PublicPermit calldata permit
+        IPodERC20.PublicPermit calldata permit
     ) internal {
         if (block.timestamp > permit.deadline) {
             revert PermitExpired(permit.deadline);
@@ -983,7 +995,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
         address from,
         address to,
         uint256 amount,
-        PublicPermit calldata permit,
+        IPodERC20.PublicPermit calldata permit,
         uint256 totalValueWei,
         uint256 callbackFeeLocalWei
     ) internal returns (bytes32 requestId) {

--- a/contracts/pod/token/perc20/PodERC20.sol
+++ b/contracts/pod/token/perc20/PodERC20.sol
@@ -67,27 +67,6 @@ contract PodERC20 is InboxUser, PodErc7984Mixin, ReentrancyGuard, Ownable {
     /// @notice Minimum age (seconds) before {killStaleRequest} may terminalize a Pending request (`0` = no wait).
     uint64 public requestKillMinAge = 1 days;
 
-    // --- Events ({IPodERC20} events redeclared here so {PodERC20} can emit without implementing burn) ---
-
-    event Transfer(
-        address indexed from,
-        address indexed to,
-        ctUint256 senderValue,
-        ctUint256 receiverValue
-    );
-    event TransferFailed(address indexed from, address indexed to, bytes errorMsg);
-    event Approval(
-        address indexed owner,
-        address indexed spender,
-        ctUint256 ownerValue,
-        ctUint256 spenderValue
-    );
-    event RequestCallbackFailed(address from, address to, bytes32 requestId, bytes callbackData);
-    event BalanceSynced(address account, ctUint256 amount);
-    event BalanceSyncSkipped(address indexed account, uint256 incomingNonce, uint256 currentNonce);
-    event RequestStatusUpdated(bytes32 indexed requestId, IPodERC20.RequestStatus status);
-    event StaleRequestKilled(bytes32 indexed requestId, address indexed account, address indexed spender);
-
     // --- Events (PoD-specific) ---
 
     /// @notice Async transfer request was submitted to COTI.
@@ -361,7 +340,7 @@ contract PodERC20 is InboxUser, PodErc7984Mixin, ReentrancyGuard, Ownable {
                 _balances[from] = newBalanceFrom;
                 balanceNonces[from] = nonce;
             } else {
-                emit BalanceSyncSkipped(from, nonce, balanceNonces[from]);
+                emit IPodERC20.BalanceSyncSkipped(from, nonce, balanceNonces[from]);
             }
         }
         if (to != address(0)) {
@@ -369,18 +348,18 @@ contract PodERC20 is InboxUser, PodErc7984Mixin, ReentrancyGuard, Ownable {
                 _balances[to] = newBalanceTo;
                 balanceNonces[to] = nonce;
             } else {
-                emit BalanceSyncSkipped(to, nonce, balanceNonces[to]);
+                emit IPodERC20.BalanceSyncSkipped(to, nonce, balanceNonces[to]);
             }
         }
         bytes memory callbackData = _requestCallbacks[sourceRequestId];
-        emit Transfer(from, to, senderValue, receiverValue);
+        emit IPodERC20.Transfer(from, to, senderValue, receiverValue);
         _emitConfidentialTransfer(from, to, senderValue, receiverValue);
         if (callbackData.length != 0) {
             (bool success, ) = address(to).call(callbackData);
             if (success) {
                 delete _requestCallbacks[sourceRequestId];
             } else {
-                emit RequestCallbackFailed(from, to, sourceRequestId, callbackData);
+                emit IPodERC20.RequestCallbackFailed(from, to, sourceRequestId, callbackData);
             }
         }
     }
@@ -398,7 +377,7 @@ contract PodERC20 is InboxUser, PodErc7984Mixin, ReentrancyGuard, Ownable {
         );
         _clearPendingByRequestId(sourceRequestId);
         _allowance[owner][spender] = IPodERC20.Allowance({spenderCiphertext: spenderAmount, ownerCiphertext: ownerAmount});
-        emit Approval(owner, spender, ownerAmount, spenderAmount);
+        emit IPodERC20.Approval(owner, spender, ownerAmount, spenderAmount);
     }
 
     /**
@@ -423,9 +402,9 @@ contract PodERC20 is InboxUser, PodErc7984Mixin, ReentrancyGuard, Ownable {
             if (balanceNonces[addresses[i]] < nonce) {
                 _balances[addresses[i]] = amounts[i];
                 balanceNonces[addresses[i]] = nonce;
-                emit BalanceSynced(addresses[i], amounts[i]);
+                emit IPodERC20.BalanceSynced(addresses[i], amounts[i]);
             } else {
-                emit BalanceSyncSkipped(addresses[i], nonce, balanceNonces[addresses[i]]);
+                emit IPodERC20.BalanceSyncSkipped(addresses[i], nonce, balanceNonces[addresses[i]]);
             }
         }
     }
@@ -449,7 +428,7 @@ contract PodERC20 is InboxUser, PodErc7984Mixin, ReentrancyGuard, Ownable {
         _setRequestStatus(sourceRequestId, IPodERC20.RequestStatus.Failed);
         failedRequests[sourceRequestId] = errorMsg;
         _clearPendingByRequestId(sourceRequestId);
-        emit TransferFailed(from, to, errorMsg);
+        emit IPodERC20.TransferFailed(from, to, errorMsg);
     }
 
     /// @notice Clears pending approval state after COTI failure.
@@ -613,7 +592,7 @@ contract PodERC20 is InboxUser, PodErc7984Mixin, ReentrancyGuard, Ownable {
         address spender = rec.spender;
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Failed);
         _clearPendingByRequestId(requestId);
-        emit StaleRequestKilled(requestId, account, spender);
+        emit IPodERC20.StaleRequestKilled(requestId, account, spender);
     }
 
     /// @param totalValueWei Total native payment (e.g. `msg.value`); `callbackFeeLocalWei` is the caller-supplied callback slice.
@@ -651,7 +630,7 @@ contract PodERC20 is InboxUser, PodErc7984Mixin, ReentrancyGuard, Ownable {
         if (status == IPodERC20.RequestStatus.Pending) {
             requestCreatedAt[requestId] = uint64(block.timestamp);
         }
-        emit RequestStatusUpdated(requestId, status);
+        emit IPodERC20.RequestStatusUpdated(requestId, status);
     }
 
     /// @dev Record an in-flight transfer/burn (`recipientLocked=false`) or mint (`recipientLocked=true`); increments {pendingTransferCount}.
@@ -702,7 +681,7 @@ contract PodERC20 is InboxUser, PodErc7984Mixin, ReentrancyGuard, Ownable {
         if (spender != address(0)) {
             emit ApprovalFailed(account, spender, errorMessage);
         } else if (account != address(0) || recipientLocked) {
-            emit TransferFailed(
+            emit IPodERC20.TransferFailed(
                 recipientLocked ? address(0) : account,
                 recipientLocked ? account : address(0),
                 errorMessage

--- a/contracts/pod/token/perc20/PodErc20Mintable.sol
+++ b/contracts/pod/token/perc20/PodErc20Mintable.sol
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "./PodERC20.sol";
+import "./extensions/PodERC20Burnable.sol";
 
 /// @title PodErc20Mintable
-/// @notice {PodERC20} variant that permits `mint` calls from a single `minter` address.
+/// @notice {PodERC20Burnable} variant that permits `mint` calls from a single `minter` address.
 /// @dev The minter is set at construction/initialize and may later be rotated by the Ownable owner via {setMinter}
 ///      (typically the {PrivacyPortalFactory} when remapping an existing pToken to a new portal). All other behavior
-///      (transfers, approvals, burns, syncing) is inherited verbatim from {PodERC20}.
-contract PodErc20Mintable is PodERC20 {
+///      (transfers, approvals, burns, syncing) is inherited verbatim from {PodERC20Burnable}.
+///      Does not inherit {PodERC20Pausable} — Privacy Portal pTokens stay unpausable at the token layer.
+contract PodErc20Mintable is PodERC20Burnable {
     /// @notice Sole address allowed to call {PodERC20.mint} (encrypted or plain variant).
     address public minter;
     bool private _mintableInitialized;

--- a/contracts/pod/token/perc20/extensions/PodERC20Burnable.sol
+++ b/contracts/pod/token/perc20/extensions/PodERC20Burnable.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../PodERC20.sol";
+
+/// @title PodERC20Burnable
+/// @notice OpenZeppelin-style extension: public burn entry points delegating to {PodERC20._burn} / {_burnPublic}.
+/// @dev Mirrors {ERC20Burnable}: base keeps internal burn machinery; this contract only exposes `burn`.
+///      Implements the full {IPodERC20} surface (including {burn}) without an explicit `is IPodERC20` clause
+///      to avoid duplicate-base override requirements against {PodERC20}'s concrete externals.
+abstract contract PodERC20Burnable is PodERC20 {
+    /// @dev See {IPodERC20}.
+    function burn(itUint256 calldata value, uint256 callbackFeeLocalWei) external payable returns (bytes32 requestId) {
+        return _burn(msg.sender, value, msg.value, callbackFeeLocalWei);
+    }
+
+    /// @dev See {IPodERC20}.
+    function burn(uint256 amount, uint256 callbackFeeLocalWei) external payable returns (bytes32 requestId) {
+        return _burnPublic(msg.sender, amount, msg.value, callbackFeeLocalWei);
+    }
+}

--- a/contracts/pod/token/perc20/extensions/PodERC20Pausable.sol
+++ b/contracts/pod/token/perc20/extensions/PodERC20Pausable.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@openzeppelin/contracts/utils/Pausable.sol";
+import "../PodERC20.sol";
+
+/// @title PodERC20Pausable
+/// @notice OpenZeppelin-style extension: gates async user operations while paused via {_sendPodTwoWay}.
+/// @dev Mirrors {ERC20Pausable}: no public {pause}/{unpause}; concrete tokens must expose them with access control.
+///      Not inherited by {PodErc20Mintable} (Privacy Portal pTokens stay unpausable at the token layer).
+abstract contract PodERC20Pausable is PodERC20, Pausable {
+    /// @inheritdoc PodERC20
+    function _sendPodTwoWay(
+        uint256 totalValueWei,
+        uint256 callbackFeeLocalWei,
+        IInbox.MpcMethodCall memory mpcMethodCall,
+        bytes4 callbackSelector_,
+        bytes4 errorSelector_
+    ) internal virtual override returns (bytes32) {
+        _requireNotPaused();
+        return super._sendPodTwoWay(
+            totalValueWei,
+            callbackFeeLocalWei,
+            mpcMethodCall,
+            callbackSelector_,
+            errorSelector_
+        );
+    }
+}

--- a/contracts/pod/token/perc20/mocks/PodERC20PausableMock.sol
+++ b/contracts/pod/token/perc20/mocks/PodERC20PausableMock.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../extensions/PodERC20Burnable.sol";
+import "../extensions/PodERC20Pausable.sol";
+import "../../../IInbox.sol";
+
+/// @title PodERC20PausableMock
+/// @notice Test/deploy helper combining {PodERC20Burnable} and {PodERC20Pausable} with owner-gated pause controls.
+/// @dev Not used by {PrivacyPortalFactory}; demonstrates the OZ pattern where the concrete token exposes {pause}/{unpause}.
+contract PodERC20PausableMock is PodERC20Pausable, PodERC20Burnable {
+    constructor(
+        uint256 _cotiChainId,
+        address _inbox,
+        address _cotiSideContract,
+        string memory _name,
+        string memory _symbol
+    ) PodERC20(_cotiChainId, _inbox, _cotiSideContract, _name, _symbol) {}
+
+    function _sendPodTwoWay(
+        uint256 totalValueWei,
+        uint256 callbackFeeLocalWei,
+        IInbox.MpcMethodCall memory mpcMethodCall,
+        bytes4 callbackSelector_,
+        bytes4 errorSelector_
+    ) internal override(PodERC20, PodERC20Pausable) returns (bytes32) {
+        return PodERC20Pausable._sendPodTwoWay(
+            totalValueWei,
+            callbackFeeLocalWei,
+            mpcMethodCall,
+            callbackSelector_,
+            errorSelector_
+        );
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+}

--- a/test/pod/token/PodERC20.pausable.test.ts
+++ b/test/pod/token/PodERC20.pausable.test.ts
@@ -1,0 +1,35 @@
+import hre from "hardhat";
+import { expect } from "chai";
+
+describe("PodERC20PausableMock", function () {
+  async function deployPausableMock() {
+    const [owner, other] = await hre.ethers.getSigners();
+    const Mock = await hre.ethers.getContractFactory("PodERC20PausableMock");
+    const pToken = await Mock.deploy(7082400, other.address, other.address, "Private USD", "pUSD");
+    await pToken.waitForDeployment();
+    await owner.sendTransaction({ to: await pToken.getAddress(), value: hre.ethers.parseEther("0.01") });
+    return { pToken, owner, other };
+  }
+
+  it("blocks transfer and burn while paused; restores after unpause", async function () {
+    const { pToken, owner, other } = await deployPausableMock();
+    const to = other.address;
+
+    await pToken.connect(owner).pause();
+
+    await expect(
+      pToken["transfer(address,uint256,uint256)"](to, 1n, 1n, { value: 1n })
+    ).to.be.revertedWithCustomError(pToken, "EnforcedPause");
+    await expect(pToken["burn(uint256,uint256)"](1n, 1n, { value: 1n })).to.be.revertedWithCustomError(
+      pToken,
+      "EnforcedPause"
+    );
+
+    await pToken.connect(owner).unpause();
+
+    await expect(pToken["burn(uint256,uint256)"](0n, 1n, { value: 1n })).to.be.revertedWithCustomError(
+      pToken,
+      "ZeroAmount"
+    );
+  });
+});

--- a/test/pod/token/PodERC20.zeroAmount.test.ts
+++ b/test/pod/token/PodERC20.zeroAmount.test.ts
@@ -4,8 +4,8 @@ import { expect } from "chai";
 describe("PodERC20 PP-05 zero public amounts", function () {
   async function deployPToken() {
     const [owner, other] = await hre.ethers.getSigners();
-    const PToken = await hre.ethers.getContractFactory("PodERC20");
-    const pToken = await PToken.deploy(7082400, other.address, other.address, "Private USD", "pUSD");
+    const PToken = await hre.ethers.getContractFactory("PodErc20Mintable");
+    const pToken = await PToken.deploy(owner.address, 7082400, other.address, other.address, "Private USD", "pUSD");
     await pToken.waitForDeployment();
     await owner.sendTransaction({ to: await pToken.getAddress(), value: hre.ethers.parseEther("0.01") });
     return { pToken, owner, other };


### PR DESCRIPTION
## Summary
- Split `PodERC20` into a bare base plus OpenZeppelin-style extensions: `PodERC20Burnable` (public `burn` wrappers) and `PodERC20Pausable` (gates `_sendPodTwoWay` while paused).
- Privacy Portal pTokens (`PodErc20Mintable` → `PodErc20MintableInitializable`) inherit **Burnable only** — no token-level pause; portal/factory pause behavior is unchanged.
- Move `{IPodERC20}` events onto `PodERC20` so the bare base can emit without implementing `burn`; add `PodERC20PausableMock` and a pause regression test.

## Test plan
- [x] `test/pod/token/PodERC20.zeroAmount.test.ts` (deploys `PodErc20Mintable`)
- [x] `test/pod/token/PodERC20.pausable.test.ts` (new)
- [x] `test/pod/token/PodERC20.selfTransfer.test.ts`
- [x] `test/pod/token/PodERC20.pendingCount.test.ts`
- [ ] `npm run compile && npm run check:bytecode-size` (CI / local)


Made with [Cursor](https://cursor.com)