### PR TITLE
Zokyo wave-1+2: portal/pToken Lows remediation

### DIFF
--- a/contracts/pod/privacy/IPodPriceOracle.sol
+++ b/contracts/pod/privacy/IPodPriceOracle.sol
@@ -7,7 +7,8 @@ pragma solidity ^0.8.20;
 ///
 /// Implemented by {PoDPriceOracle} (portal + inbox), {BandLiveOracle}, and {ChainlinkLiveOracle}.
 /// Feed adapters never revert; return `0` when a feed is unset, stale, or failed.
-/// Zero rates make {PrivacyPortalFeeLib.resolvePortalFee} skip dynamic pricing (fixed fee only).
+/// Zero rates make {PrivacyPortalFeeLib.resolvePortalFee} revert {ZeroUsdRate} when a percentage
+/// fee is configured (`percentageBps != 0`); fixed-only fees still succeed.
 interface IPodPriceOracle {
     /// @notice Live USD price for `token`.
     function getLivePrice(address token) external view returns (uint256 priceUsd);

--- a/contracts/pod/privacy/IPrivacyPortal.sol
+++ b/contracts/pod/privacy/IPrivacyPortal.sol
@@ -165,8 +165,10 @@ interface IPrivacyPortal {
     /// @param requestId Mint request id returned by {deposit} / {depositNative} / {wrap}.
     function adminRefundPendingDeposit(bytes32 requestId) external;
 
-    /// @notice Mark a pending withdrawal as Failed after its pToken transfer request fails.
-    /// @dev Does not release underlying; user retains pTokens. Portal protocol fee is kept.
+    /// @notice Mark a pending withdrawal as Failed after its pToken transfer fails with far-side evidence.
+    /// @dev Allows {IPodERC20.RequestStatus.SystemFailed}, or Failed with non-empty {IPodERC20.failedRequests}.
+    ///      Local kill/invalidate (Failed, empty evidence) cannot cancel. Does not release underlying; user retains
+    ///      pTokens. Portal protocol fee is kept.
     /// @param withdrawalId Portal withdrawal id from {requestWithdrawWithPermit}.
     function cancelFailedWithdrawal(bytes32 withdrawalId) external;
 

--- a/contracts/pod/privacy/PrivacyPortal.sol
+++ b/contracts/pod/privacy/PrivacyPortal.sol
@@ -199,6 +199,8 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Pausable, Reent
     error BatchBurnNotResolved(bytes32 requestId, IPodERC20.RequestStatus status);
     /// @notice Transfer request is not Failed/SystemFailed, so withdrawal cannot be cancelled.
     error WithdrawTransferNotFailed(bytes32 requestId, IPodERC20.RequestStatus status);
+    /// @notice Transfer is Failed but has no far-side failure evidence (e.g. local kill/invalidate).
+    error WithdrawTransferMissingFailureEvidence(bytes32 requestId);
     /// @notice Portal underlying is not configured for native wrap deposits.
     error NativeWrapDisabled();
     /// @notice Factory pause controller is not configured.
@@ -643,6 +645,8 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Pausable, Reent
     }
 
     /// @inheritdoc IPrivacyPortal
+    /// @dev Cancel only when the pToken shows SystemFailed, or Failed with non-empty {IPodERC20.failedRequests}
+    ///      (far-side raise / mother failure). Local kill or invalidate leaves Failed with empty evidence and must not cancel.
     function cancelFailedWithdrawal(bytes32 withdrawalId) external override nonReentrant {
         Withdrawal storage withdrawal = withdrawals[withdrawalId];
         if (withdrawal.user == address(0)) {
@@ -651,16 +655,20 @@ contract PrivacyPortal is IPrivacyPortal, IERC7984PortalWrapper, Pausable, Reent
         if (withdrawal.status != WithdrawalStatus.TransferPending) {
             revert WithdrawalNotPending(withdrawalId, withdrawal.status);
         }
-        IPodERC20.RequestStatus requestStatus = pToken.requests(withdrawal.transferRequestId).status;
-        if (
-            requestStatus != IPodERC20.RequestStatus.Failed
-                && requestStatus != IPodERC20.RequestStatus.SystemFailed
-        ) {
-            revert WithdrawTransferNotFailed(withdrawal.transferRequestId, requestStatus);
+        bytes32 transferRequestId = withdrawal.transferRequestId;
+        IPodERC20.RequestStatus requestStatus = pToken.requests(transferRequestId).status;
+        if (requestStatus == IPodERC20.RequestStatus.SystemFailed) {
+            // SystemFailed is sufficient far-side evidence on its own.
+        } else if (requestStatus == IPodERC20.RequestStatus.Failed) {
+            if (pToken.failedRequests(transferRequestId).length == 0) {
+                revert WithdrawTransferMissingFailureEvidence(transferRequestId);
+            }
+        } else {
+            revert WithdrawTransferNotFailed(transferRequestId, requestStatus);
         }
 
         withdrawal.status = WithdrawalStatus.Failed;
-        emit WithdrawalFailed(withdrawalId, withdrawal.transferRequestId);
+        emit WithdrawalFailed(withdrawalId, transferRequestId);
     }
 
     /// @inheritdoc IPrivacyPortal

--- a/contracts/pod/privacy/PrivacyPortalFeeLib.sol
+++ b/contracts/pod/privacy/PrivacyPortalFeeLib.sol
@@ -19,6 +19,8 @@ library PrivacyPortalFeeLib {
     error FeeOverflow();
     /// @notice Invalid fee configuration.
     error InvalidFeeConfiguration();
+    /// @notice Percentage fee requested but a USD rate is zero (fail closed).
+    error ZeroUsdRate();
 
     /// @notice Pack fee config into one storage slot: uint96 fixed | uint32 bps | uint128 max.
     function packFeeConfig(uint256 fixedFee, uint256 percentageBps, uint256 maxFee)
@@ -75,7 +77,8 @@ library PrivacyPortalFeeLib {
     }
 
     /// @notice Resolve portal fee from packed config and live USD rates.
-    /// @dev Falls back to `fixedFee` (no dynamic pricing) when `percentageBps == 0` or either rate is zero.
+    /// @dev When `percentageBps == 0`, returns `fixedFee` only. When `percentageBps != 0`, both USD
+    ///      rates must be non-zero or the call reverts {ZeroUsdRate} (fail closed on a dead feed).
     function resolvePortalFee(
         bytes32 packedFeeConfig,
         uint256 amount,
@@ -85,8 +88,11 @@ library PrivacyPortalFeeLib {
     ) internal pure returns (uint256 fee, bool usedDynamicPricing) {
         (uint96 fixedFee, uint32 percentageBps, uint128 maxFee) = unpackFeeConfig(packedFeeConfig);
 
-        if (percentageBps == 0 || collateralUsdRate == 0 || nativeUsdRate == 0) {
+        if (percentageBps == 0) {
             return (fixedFee, false);
+        }
+        if (collateralUsdRate == 0 || nativeUsdRate == 0) {
+            revert ZeroUsdRate();
         }
 
         uint256 txValueUsd = Math.mulDiv(amount, collateralUsdRate, 10 ** uint256(decimals));

--- a/contracts/pod/privacy/mocks/MockPodERC20ForPortal.sol
+++ b/contracts/pod/privacy/mocks/MockPodERC20ForPortal.sol
@@ -31,6 +31,7 @@ contract MockPodERC20ForPortal {
     IPodERC20.RequestStatus private _lastBurnStatus;
 
     mapping(bytes32 => IPodERC20.RequestStatus) private _requestStatus;
+    mapping(bytes32 => bytes) public failedRequests;
 
     function estimateFee()
         external
@@ -131,6 +132,17 @@ contract MockPodERC20ForPortal {
         _lastTransferStatus = IPodERC20.RequestStatus.Failed;
         if (lastTransferRequestId != bytes32(0)) {
             _requestStatus[lastTransferRequestId] = IPodERC20.RequestStatus.Failed;
+            // Far-side raise / mother failure populates evidence (same shape as real PodERC20).
+            failedRequests[lastTransferRequestId] = hex"01";
+        }
+    }
+
+    /// @dev Local kill/invalidate shape: Failed with empty failedRequests.
+    function markLastTransferFailedWithoutEvidence() external {
+        _lastTransferStatus = IPodERC20.RequestStatus.Failed;
+        if (lastTransferRequestId != bytes32(0)) {
+            _requestStatus[lastTransferRequestId] = IPodERC20.RequestStatus.Failed;
+            delete failedRequests[lastTransferRequestId];
         }
     }
 

--- a/contracts/pod/privacy/mocks/PrivacyPortalFeeLibHarness.sol
+++ b/contracts/pod/privacy/mocks/PrivacyPortalFeeLibHarness.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "../PrivacyPortalFeeLib.sol";
+
+/// @dev Test harness exposing {PrivacyPortalFeeLib} pure helpers.
+contract PrivacyPortalFeeLibHarness {
+    function packFeeConfig(uint256 fixedFee, uint256 percentageBps, uint256 maxFee)
+        external
+        pure
+        returns (bytes32)
+    {
+        return PrivacyPortalFeeLib.packFeeConfig(fixedFee, percentageBps, maxFee);
+    }
+
+    function resolvePortalFee(
+        bytes32 packedFeeConfig,
+        uint256 amount,
+        uint8 decimals,
+        uint256 collateralUsdRate,
+        uint256 nativeUsdRate
+    ) external pure returns (uint256 fee, bool usedDynamicPricing) {
+        return PrivacyPortalFeeLib.resolvePortalFee(
+            packedFeeConfig, amount, decimals, collateralUsdRate, nativeUsdRate
+        );
+    }
+}

--- a/contracts/pod/token/perc20/IPodERC20.sol
+++ b/contracts/pod/token/perc20/IPodERC20.sol
@@ -304,6 +304,9 @@ interface IPodERC20 {
      */
     function killStaleRequest(bytes32 requestId) external;
 
+    /// @notice Failure payload for a request that failed with far-side evidence (empty after local kill/invalidate).
+    function failedRequests(bytes32 requestId) external view returns (bytes memory);
+
     /// @notice Minimum age (seconds) before {killStaleRequest} may terminalize a Pending request.
     function requestKillMinAge() external view returns (uint64);
 

--- a/contracts/pod/token/perc20/IPodERC20.sol
+++ b/contracts/pod/token/perc20/IPodERC20.sol
@@ -311,7 +311,8 @@ interface IPodERC20 {
     function requestKillMinAge() external view returns (uint64);
 
     /// @notice Owner: set {requestKillMinAge} (`0` disables age gating — kill allowed immediately).
-    /// @dev Factory-deployed tokens: call via {IPrivacyPortalFactoryAdmin.setPTokenRequestKillMinAge}.
+    /// @dev Positive values must be at least 3 days. Factory-deployed tokens: call via
+    ///      {IPrivacyPortalFactoryAdmin.setPTokenRequestKillMinAge}.
     function setRequestKillMinAge(uint64 seconds_) external;
 
     /// @dev Reserved: burn garbled amount; not supported in reference flows.

--- a/contracts/pod/token/perc20/PodERC20.sol
+++ b/contracts/pod/token/perc20/PodERC20.sol
@@ -64,7 +64,8 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
     /// @notice Timestamp when a request last entered Pending (for {killStaleRequest}).
     mapping(bytes32 => uint64) public requestCreatedAt;
     /// @notice Minimum age (seconds) before {killStaleRequest} may terminalize a Pending request (`0` = no wait).
-    uint64 public requestKillMinAge = 1 days;
+    /// @dev Default is 3 days so kill cannot race the typical 48h inbox message-life refund path.
+    uint64 public requestKillMinAge = 3 days;
 
     // --- Events (PoD-specific; {Transfer}, {Approval}, etc. are declared on {IPodERC20}) ---
 
@@ -84,6 +85,9 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
     event PeerConfigured(address indexed inbox, address indexed cotiSideContract);
 
     // --- Errors ---
+
+    /// @notice {setRequestKillMinAge} used a positive age below the 3-day floor.
+    error RequestKillMinAgeTooShort(uint64 seconds_);
 
     /// @notice Public-amount transfer, burn, or mint used a zero value.
     error ZeroAmount();
@@ -552,7 +556,7 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
         decimals = _decimals;
         totalSupply = 0;
         // Inline default — clones do not run the constructor storage initializer.
-        requestKillMinAge = 1 days;
+        requestKillMinAge = 3 days;
     }
 
     /**
@@ -581,7 +585,11 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
 
     /// @inheritdoc IPodERC20
     /// @dev Factory-deployed tokens: call via {IPrivacyPortalFactoryAdmin.setPTokenRequestKillMinAge}.
+    ///      `0` disables the age gate; any positive value must be at least 3 days.
     function setRequestKillMinAge(uint64 seconds_) external onlyOwner {
+        if (seconds_ != 0 && seconds_ < 3 days) {
+            revert RequestKillMinAgeTooShort(seconds_);
+        }
         requestKillMinAge = seconds_;
     }
 

--- a/contracts/pod/token/perc20/PodERC20.sol
+++ b/contracts/pod/token/perc20/PodERC20.sol
@@ -574,13 +574,20 @@ contract PodERC20 is IPodERC20, InboxUser, PodErc7984Mixin, ReentrancyGuard, Own
     /// @notice Minter-only: mark a Pending request Failed and clear pending locks.
     /// @dev Blocks a later Success callback from settling (monotonic status). Used when portal admin
     ///      refunds deposit collateral while a mint is still Pending.
+    ///      Auth via {_checkInvalidatePendingAuth} (mintable tokens also admit {previousMinter}).
     function invalidatePendingRequest(bytes32 requestId) external {
-        _checkMinter();
+        _checkInvalidatePendingAuth();
         if (_requests[requestId].status != IPodERC20.RequestStatus.Pending) {
             revert RequestNotPending(requestId, _requests[requestId].status);
         }
         _setRequestStatus(requestId, IPodERC20.RequestStatus.Failed);
         _clearPendingByRequestId(requestId);
+    }
+
+    /// @dev Auth for {invalidatePendingRequest}. Base uses {_checkMinter}; mintable overrides to
+    ///      also allow {PodErc20Mintable.previousMinter}.
+    function _checkInvalidatePendingAuth() internal view virtual {
+        _checkMinter();
     }
 
     /// @inheritdoc IPodERC20

--- a/contracts/pod/token/perc20/PodErc20Mintable.sol
+++ b/contracts/pod/token/perc20/PodErc20Mintable.sol
@@ -11,6 +11,8 @@ import "./PodERC20.sol";
 contract PodErc20Mintable is PodERC20 {
     /// @notice Sole address allowed to call {PodERC20.mint} (encrypted or plain variant).
     address public minter;
+    /// @notice Prior minter retained so a retired portal can still {invalidatePendingRequest}.
+    address public previousMinter;
     bool private _mintableInitialized;
 
     /// @notice Emitted when the authorized minter is rotated.
@@ -46,6 +48,14 @@ contract PodErc20Mintable is PodERC20 {
     /// @dev Allows the call only when `msg.sender == minter`; reverts with {OnlyMinter} otherwise.
     function _checkMinter() internal view override {
         if (msg.sender != minter) {
+            revert OnlyMinter(msg.sender);
+        }
+    }
+
+    /// @inheritdoc PodERC20
+    /// @dev Current or previous minter may invalidate (remount leaves pending escrows on the old portal).
+    function _checkInvalidatePendingAuth() internal view override {
+        if (msg.sender != minter && msg.sender != previousMinter) {
             revert OnlyMinter(msg.sender);
         }
     }
@@ -98,6 +108,7 @@ contract PodErc20Mintable is PodERC20 {
             revert PodErc20MintableInvalidMinter();
         }
         address previous = minter;
+        previousMinter = previous;
         minter = newMinter;
         emit MinterUpdated(previous, newMinter);
     }

--- a/test/pod/privacy/PrivacyPortal.recovery.test.ts
+++ b/test/pod/privacy/PrivacyPortal.recovery.test.ts
@@ -280,6 +280,44 @@ describe("PrivacyPortal failed-request recovery", function () {
         expect(withdrawal.status).to.equal(3n) // WithdrawalStatus.Failed
     })
 
+    it("rejects cancel when transfer is Failed without far-side evidence", async function () {
+        const { user, portal, pToken, amount } = await deployPortalFixture()
+
+        const deadline = BigInt(Math.floor(Date.now() / 1000) + 3600)
+        const tx = await portal.connect(user).requestWithdrawWithPermit(
+            user.address,
+            amount,
+            0,
+            1000,
+            100,
+            deadline,
+            27,
+            hre.ethers.ZeroHash,
+            hre.ethers.ZeroHash,
+            { value: 1000 }
+        )
+        const receipt = await tx.wait()
+        const withdrawLog = receipt!.logs
+            .map((log) => {
+                try {
+                    return portal.interface.parseLog(log)
+                } catch {
+                    return null
+                }
+            })
+            .find((parsed) => parsed?.name === "WithdrawalRequested")
+        const withdrawalId = withdrawLog!.args.withdrawalId as string
+        const transferRequestId = withdrawLog!.args.transferRequestId as string
+
+        await pToken.markLastTransferFailedWithoutEvidence()
+        await expect(portal.cancelFailedWithdrawal(withdrawalId))
+            .to.be.revertedWithCustomError(portal, "WithdrawTransferMissingFailureEvidence")
+            .withArgs(transferRequestId)
+
+        const withdrawal = await portal.withdrawals(withdrawalId)
+        expect(withdrawal.status).to.equal(1n) // WithdrawalStatus.TransferPending
+    })
+
     it("rescues native and ERC20 to the factory rescue recipient while paused", async function () {
         const { owner, other, factory, underlying, portal, pToken } = await deployPortalFixture()
         const rescueTo = other.address

--- a/test/pod/privacy/PrivacyPortalFactory.createPortalWithExistingPToken.test.ts
+++ b/test/pod/privacy/PrivacyPortalFactory.createPortalWithExistingPToken.test.ts
@@ -236,6 +236,27 @@ describe("PodErc20Mintable.setMinter", function () {
             .to.emit(token, "MinterUpdated")
             .withArgs(minter.address, newMinter.address)
         expect(await token.minter()).to.equal(newMinter.address)
+        expect(await token.previousMinter()).to.equal(minter.address)
+    })
+
+    it("lets previousMinter invalidate after rotation; stranger cannot", async function () {
+        const { minter, newMinter, stranger, token } = await deployMintable()
+        await token.setMinter(newMinter.address)
+
+        const fakeId = hre.ethers.ZeroHash
+        // Auth passes for previous minter; no Pending record → RequestNotPending.
+        await expect(token.connect(minter).invalidatePendingRequest(fakeId)).to.be.revertedWithCustomError(
+            token,
+            "RequestNotPending"
+        )
+        await expect(token.connect(newMinter).invalidatePendingRequest(fakeId)).to.be.revertedWithCustomError(
+            token,
+            "RequestNotPending"
+        )
+        await expect(token.connect(stranger).invalidatePendingRequest(fakeId)).to.be.revertedWithCustomError(
+            token,
+            "OnlyMinter"
+        )
     })
 
     it("reverts setMinter for non-owner", async function () {

--- a/test/pod/privacy/PrivacyPortalFactory.pTokenAdmin.test.ts
+++ b/test/pod/privacy/PrivacyPortalFactory.pTokenAdmin.test.ts
@@ -67,13 +67,16 @@ describe("PrivacyPortalFactory pToken admin forwarders", function () {
 
     it("admin can setPTokenRequestKillMinAge; non-admin and unknown pToken revert", async function () {
         const { factory, stranger, pToken, pTokenAddr } = await deployFactoryFixture()
-        expect(await pToken.requestKillMinAge()).to.equal(86400n)
+        expect(await pToken.requestKillMinAge()).to.equal(259200n) // 3 days
 
         await factory.setPTokenRequestKillMinAge(pTokenAddr, 0)
         expect(await pToken.requestKillMinAge()).to.equal(0n)
 
-        await expect(factory.connect(stranger).setPTokenRequestKillMinAge(pTokenAddr, 1)).to.be.reverted
-        await expect(factory.setPTokenRequestKillMinAge(ZeroAddress, 1))
+        await expect(factory.setPTokenRequestKillMinAge(pTokenAddr, 1))
+            .to.be.revertedWithCustomError(pToken, "RequestKillMinAgeTooShort")
+
+        await expect(factory.connect(stranger).setPTokenRequestKillMinAge(pTokenAddr, 259200)).to.be.reverted
+        await expect(factory.setPTokenRequestKillMinAge(ZeroAddress, 259200))
             .to.be.revertedWithCustomError(factory, "UnknownPToken")
             .withArgs(ZeroAddress)
     })
@@ -119,7 +122,7 @@ describe("PrivacyPortalFactory pToken admin forwarders", function () {
 
     it("honors requestKillMinAge before factory kill", async function () {
         const { owner, factory, pToken, pTokenAddr } = await deployFactoryFixture()
-        // Default min age is 1 day.
+        // Default min age is 3 days.
         await owner.sendTransaction({ to: pTokenAddr, value: 1000n })
         const syncTx = await pToken.syncBalances([owner.address], 100n, { value: 1000n })
         const syncReceipt = await syncTx.wait()
@@ -139,7 +142,7 @@ describe("PrivacyPortalFactory pToken admin forwarders", function () {
             "RequestNotAged"
         )
 
-        await hre.network.provider.send("evm_increaseTime", [86400])
+        await hre.network.provider.send("evm_increaseTime", [259200])
         await hre.network.provider.send("evm_mine")
 
         await expect(factory.killPTokenStaleRequest(pTokenAddr, requestId)).to.emit(

--- a/test/pod/privacy/PrivacyPortalFeeLib.test.ts
+++ b/test/pod/privacy/PrivacyPortalFeeLib.test.ts
@@ -1,0 +1,42 @@
+import { expect } from "chai"
+import hre from "hardhat"
+
+describe("PrivacyPortalFeeLib resolvePortalFee", function () {
+    async function deployHarness() {
+        const Harness = await hre.ethers.getContractFactory("PrivacyPortalFeeLibHarness")
+        const harness = await Harness.deploy()
+        await harness.waitForDeployment()
+        return harness
+    }
+
+    it("reverts ZeroUsdRate when percentageBps is set and a USD rate is zero", async function () {
+        const harness = await deployHarness()
+        const packed = await harness.packFeeConfig(1n, 100n, 1000n)
+        await expect(harness.resolvePortalFee(packed, 1_000_000n, 6, 0n, 10n ** 18n)).to.be.revertedWithCustomError(
+            harness,
+            "ZeroUsdRate"
+        )
+        await expect(harness.resolvePortalFee(packed, 1_000_000n, 6, 10n ** 18n, 0n)).to.be.revertedWithCustomError(
+            harness,
+            "ZeroUsdRate"
+        )
+    })
+
+    it("returns fixedFee when percentageBps is zero even if rates are zero", async function () {
+        const harness = await deployHarness()
+        const packed = await harness.packFeeConfig(42n, 0n, 1000n)
+        const [fee, usedDynamic] = await harness.resolvePortalFee(packed, 1_000_000n, 6, 0n, 0n)
+        expect(fee).to.equal(42n)
+        expect(usedDynamic).to.equal(false)
+    })
+
+    it("uses dynamic pricing when percentageBps and both rates are non-zero", async function () {
+        const harness = await deployHarness()
+        const packed = await harness.packFeeConfig(1n, 100_000n, 10n ** 18n) // 10%
+        const amount = 10n ** 6n // 1 token @ 6 decimals
+        const rate = 10n ** 18n // $1
+        const [fee, usedDynamic] = await harness.resolvePortalFee(packed, amount, 6, rate, rate)
+        expect(usedDynamic).to.equal(true)
+        expect(fee).to.be.gt(1n)
+    })
+})


### PR DESCRIPTION
## Summary
- Wave-1: far-side failure evidence required to cancel pending withdrawals (and prior wave-1 items on this branch)
- Wave-2 Lows so far: portal % fee fails closed on zero USD rate; pToken `requestKillMinAge` default 3 days; `previousMinter` may still `invalidatePendingRequest` after remount
- Remaining on this branch (not yet in this push if incomplete): Z-26/27/30/31/32/39/41 — check latest commits

## Test plan
- [ ] `npx hardhat test --network hardhat test/pod/privacy/PrivacyPortalFeeLib.test.ts`
- [ ] `npx hardhat test --network hardhat test/pod/privacy/PrivacyPortalFactory.pTokenAdmin.test.ts`
- [ ] `npx hardhat test --network hardhat test/pod/privacy/PrivacyPortalFactory.createPortalWithExistingPToken.test.ts`